### PR TITLE
Remove the unused '.' path in data_files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(name='pyang',
       scripts=['bin/pyang', 'bin/yang2html', 'bin/yang2dsdl', 'bin/json2xml'],
       packages=['pyang', 'pyang.plugins', 'pyang.translators'],
       data_files=[
-            ('.', []),
             ('share/man/man1', man1),
             ('share/yang/modules', modules),
             ('share/yang/xslt', xslt),


### PR DESCRIPTION
When using pip to uninstall the pyang package, the '.' caused all of
/usr/local/ to be removed.