### PR TITLE
Implement try/except block for plugin directory listing

### DIFF
--- a/pyang/plugin.py
+++ b/pyang/plugin.py
@@ -29,7 +29,10 @@ def init(plugindirs=[]):
     syspath = sys.path
     for plugindir in plugindirs:
         sys.path = [plugindir] + syspath
-        fnames = os.listdir(plugindir)
+        try:
+            fnames = os.listdir(plugindir)
+        except OSError:
+            continue
         for fname in fnames:
             if fname.endswith(".py") and fname != '__init__.py':
                 pluginmod = __import__(fname[:-3])


### PR DESCRIPTION
Depending on the environment, it may be possible that sys.path expansion contains non-directories (e.g. zip) which could raise an OSError exception when attempting to os.listdir