### PR TITLE
Enable testing with python 3.2 in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ language: python
 python:
   # - "2.6" # error: no register_namespace in xml.etree.ElementTree
   - "2.7"
-  # - "3.2" # error building libxml2
-  # - "3.3" # error building libxml2
-  # - "3.4" # error building libxml2
+  - "3.2"
+  # - "3.3" # see http://stackoverflow.com/questions/14956313/dictionary-ordering-non-deterministic-in-python3
+  # - "3.4" # see http://stackoverflow.com/questions/14956313/dictionary-ordering-non-deterministic-in-python3
 # Some required packages are not yet whitelisted, this doesn't work yet:
 addons:
   apt:
     packages:
-      - libxml2-dev
       - xsltproc       # https://github.com/travis-ci/travis-ci/issues/3944
       - jing           # https://github.com/travis-ci/travis-ci/issues/3945
 # After the issues are closed, remove the code between {{{ and }}}:

--- a/pyang/error.py
+++ b/pyang/error.py
@@ -255,9 +255,6 @@ error_codes = \
     'PATTERN_ERROR':
       (2,
        'syntax error in pattern: %s'),
-    'PATTERN_FAILURE':
-      (4,
-       'could not verify pattern: %s'),
     'LEAFREF_TOO_MANY_UP':
       (1,
        'the path for %s at %s has too many ".."'),

--- a/pyang/types.py
+++ b/pyang/types.py
@@ -397,20 +397,12 @@ class LengthTypeSpec(TypeSpec):
 
 def validate_pattern_expr(errors, stmt):
     # check that it's syntactically correct
+    import re
     try:
-        import libxml2
-        try:
-            re = libxml2.regexpCompile(stmt.arg)
-            return (re, stmt.pos)
-        except libxml2.treeError as v:
-            err_add(errors, stmt.pos, 'PATTERN_ERROR', str(v))
-            return None
-    except ImportError:
-## Do not report a warning in this case.  Maybe we should add some
-## flag to turn on this warning...
-#        err_add(errors, stmt.pos, 'PATTERN_FAILURE',
-#                "Could not import python module libxml2 "
-#                    "(see http://xmlsoft.org for installation help)")
+        r = re.compile(stmt.arg)
+        return (r, stmt.pos)
+    except re.error as v:
+        err_add(errors, stmt.pos, 'PATTERN_ERROR', str(v))
         return None
 
 class PatternTypeSpec(TypeSpec):
@@ -426,7 +418,7 @@ class PatternTypeSpec(TypeSpec):
         if self.base.validate(errors, pos, val, errstr) == False:
             return False
         for (re, re_pos) in self.res:
-            if re.regexpExec(val) != 1:
+            if re.match(val) is None:
                 err_add(errors, pos, 'TYPE_VALUE',
                         (val, self.definition, 'pattern mismatch' + errstr +
                          ' for pattern defined at ' + str(re_pos)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-http://xmlsoft.org/sources/python/libxml2-python-2.6.21.tar.gz


### PR DESCRIPTION
The previous issue was a problem building libxml2 in travis.
That library was used for regular expressions only; we are now using
python's "re" module and that has freed us from the libxml2 dependency.

pyang can now be tested with python 3.2 in travis-ci.

For python 3.3 and 3.4, we still have to change some tests, as these
new python versions randomize the dictionary order and that makes the
order of some lines in some files not deterministic.