### PR TITLE
Add pyflakes and py3kwarn static checkers to travis; fix the warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y xsltproc jing
 # }}}
+install:
+  - pip install -r requirements.txt
+  - pip install --upgrade pyflakes py3kwarn
 script:
   - source env.sh
   - make test
@@ -29,3 +32,5 @@ script:
   # Test if we .gitignore any tracked files:
   - git ls-files -i --exclude-standard | tee "$TMP"
   - if test -s "$TMP"; then false; else true; fi
+  - pyflakes .
+  - py3kwarn .

--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -1,7 +1,6 @@
 """The pyang library for parsing, validating, and converting YANG modules"""
 
 import os
-import string
 import sys
 import zlib
 import re
@@ -9,7 +8,6 @@ import re
 from . import error
 from . import yang_parser
 from . import yin_parser
-from . import grammar
 from . import util
 from . import statements
 
@@ -167,7 +165,7 @@ class Context(object):
                 # now we must read the revision from the module
                 try:
                     r = self.repository.get_module_from_handle(handle)
-                except self.repository.ReadError as ex:
+                except self.repository.ReadError:
                     i += 1
                     continue
                 (ref, format, text) = r
@@ -313,7 +311,7 @@ class Context(object):
                     p = yang_parser.YangParser(extra)
 
                 return p.parse(self, ref, text)
-            except self.repository.ReadError as ex:
+            except self.repository.ReadError:
                 return None
 
     def validate(self):
@@ -418,7 +416,7 @@ class FileRepository(Repository):
         try:
             fd = open(absfilename)
             text = fd.read()
-        except IOError as ex:
+        except IOError:
             return None
         if format == 'yin':
             p = yin_parser.YinParser()

--- a/pyang/plugins/capability.py
+++ b/pyang/plugins/capability.py
@@ -3,8 +3,6 @@
 """
 
 import optparse
-import sys
-import os.path
 
 from pyang import plugin
 from pyang import util

--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -364,7 +364,7 @@ def chk_if_feature(old, new, ctx):
 def chk_config(old, new, ctx):
     if old.i_config == False and new.i_config == True:
         if statements.is_mandatory_node(new):
-            err_add(ctx.errors, newch.pos, 'CHK_MANDATORY_CONFIG', new.arg)
+            err_add(ctx.errors, new.pos, 'CHK_MANDATORY_CONFIG', new.arg)
     elif old.i_config == True and new.i_config == False:
         err_add(ctx.errors, new.pos, 'CHK_BAD_CONFIG', new.arg)
 

--- a/pyang/plugins/depend.py
+++ b/pyang/plugins/depend.py
@@ -3,7 +3,6 @@
 """
 
 import optparse
-import sys
 import os.path
 
 from pyang import plugin

--- a/pyang/plugins/hypertree.py
+++ b/pyang/plugins/hypertree.py
@@ -1,7 +1,6 @@
 
 import optparse
 import sys
-import re
 import string
 
 from pyang import plugin

--- a/pyang/plugins/ietf.py
+++ b/pyang/plugins/ietf.py
@@ -3,7 +3,6 @@ See RFC 6087
 """
 
 import optparse
-import sys
 
 from pyang import plugin
 from pyang import statements

--- a/pyang/plugins/jsonxsl.py
+++ b/pyang/plugins/jsonxsl.py
@@ -25,7 +25,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 
-from pyang import plugin, statements, error
+from pyang import plugin, error
 from pyang.util import unique_prefixes
 
 ss = ET.Element("stylesheet",

--- a/pyang/plugins/jstree.py
+++ b/pyang/plugins/jstree.py
@@ -4,7 +4,6 @@ to the YANG module(s).
 """
 
 import optparse
-import sys
 
 from pyang import plugin
 from pyang import statements
@@ -256,13 +255,6 @@ def emit_bodystart(modules, fd, ctx):
 def emit_tree(modules, fd, ctx):
     global levelcnt
     for module in modules:
-        bstr = ""
-        b = module.search_one('belongs-to')
-        if b is not None:
-            bstr = " (belongs-to %s)" % b.arg
-        ns = module.search_one('namespace')
-        if ns is not None:
-            nsstr = ns.arg
         pr = module.search_one('prefix')
         if pr is not None:
             prstr = pr.arg
@@ -342,12 +334,6 @@ def print_node(s, module, fd, prefix, ctx, level=0):
         name = s.arg
     else:
         name = s.i_module.i_prefix + ':' + s.arg
-
-    pr = module.search_one('prefix')
-    if pr is not None:
-        prstr = pr.arg
-    else:
-        prstr = ""
 
     descr = s.search_one('description')
     descrstring = "No description"
@@ -517,31 +503,26 @@ def typestring(node):
 
     def get_nontypedefstring(node):
         s = ""
-        found  = False
         t = node.search_one('type')
         if t is not None:
             s = t.arg + '\n'
             if t.arg == 'enumeration':
-                found = True
                 s = s + ' : {'
                 for enums in t.substmts:
                     s = s + enums.arg + ','
                 s = s + '}'
             elif t.arg == 'leafref':
-                found = True
                 s = s + ' : '
                 p = t.search_one('path')
                 if p is not None:
                     s = s + p.arg
 
             elif t.arg == 'identityref':
-                found = True
                 b = t.search_one('base')
                 if b is not None:
                     s = s + ' {' + b.arg + '}'
 
             elif t.arg == 'union':
-                found = True
                 uniontypes = t.search('type')
                 s = s + '{' + uniontypes[0].arg
                 for uniontype in uniontypes[1:]:
@@ -550,16 +531,13 @@ def typestring(node):
 
             typerange = t.search_one('range')
             if typerange is not None:
-                found = True
                 s = s + ' [' + typerange.arg + ']'
             length = t.search_one('length')
             if length is not None:
-                found = True
                 s = s + ' {length = ' + length.arg + '}'
 
             pattern = t.search_one('pattern')
             if pattern is not None: # truncate long patterns
-                found = True
                 s = s + ' {pattern = ' + pattern.arg + '}'
         return s
 
@@ -568,8 +546,6 @@ def typestring(node):
     if s != "":
         t = node.search_one('type')
         # chase typedef
-        type_namespace = None
-        i_type_name = None
         name = t.arg
         if name.find(":") == -1:
             prefix = None

--- a/pyang/plugins/jtox.py
+++ b/pyang/plugins/jtox.py
@@ -21,10 +21,9 @@ that can be used by the *json2xml* script for translating a valid JSON
 configuration or state data to XML.
 """
 
-import os
 import json
 
-from pyang import plugin, statements, error
+from pyang import plugin, error
 from pyang.util import unique_prefixes
 
 def pyang_plugin_init():
@@ -83,7 +82,6 @@ class JtoXPlugin(plugin.PyangPlugin):
                               for k in ch.i_key])
             elif ch.keyword in ["leaf", "leaf-list"]:
                 ndata.append(self.base_type(ch.search_one("type")))
-            modname = ch.i_module.i_modulename
             parent[nodename] = ndata
 
     def base_type(self, type):

--- a/pyang/plugins/omni.py
+++ b/pyang/plugins/omni.py
@@ -1,11 +1,8 @@
 
 import optparse
-import sys
-import re
 import string
 
 from pyang import plugin
-from pyang import statements
 
 paths_in_module = []
 leafrefs = []

--- a/pyang/plugins/sample-xml-skeleton.py
+++ b/pyang/plugins/sample-xml-skeleton.py
@@ -30,14 +30,12 @@ document containing sample elements for all data nodes.
   --sample-xml-skeleton-defaults option).
 """
 
-import os
 import sys
 import optparse
 import xml.etree.ElementTree as ET
 import copy
 
-from pyang import plugin, statements, error
-from pyang.util import unique_prefixes
+from pyang import plugin, error
 
 def pyang_plugin_init():
     plugin.register_plugin(SampleXMLSkeletonPlugin())

--- a/pyang/plugins/smi.py
+++ b/pyang/plugins/smi.py
@@ -13,7 +13,6 @@ i_smi_oid built from the smiv2:oid and smiv2:subid statements.
 
 import re
 
-import pyang
 from pyang import plugin
 from pyang import syntax
 from pyang import grammar

--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -102,7 +102,6 @@ def emit_tree(ctx, modules, fd, depth, path):
             if b is not None:
                 bstr = " (belongs-to %s)" % b.arg
             fd.write("%s: %s%s\n" % (module.keyword, module.arg, bstr))
-            printed_header = True
 
         chs = [ch for ch in module.i_children
                if ch.keyword in statements.data_definition_keywords]

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -19,8 +19,6 @@ import datetime
 import re
 
 from pyang import plugin
-from pyang import util
-from pyang import grammar
 from pyang import error
 from pyang import syntax
 from pyang import statements
@@ -362,7 +360,6 @@ class uml_emitter:
     def emit_child_stmt(self, parent, node, fd, cont = True):
          keysign = ''
          keyprefix = ''
-         uniquesign = ''
 
          # manage shorthand omitting case in choice
          if (parent.keyword == 'choice') and ((node.keyword == 'container') or (node.keyword == 'leaf') or (node.keyword == 'leaf-list') or (node.keyword == 'list')):

--- a/pyang/plugins/xmi.py
+++ b/pyang/plugins/xmi.py
@@ -1,11 +1,8 @@
 
 import optparse
-import sys
-import re
 import string
 
 from pyang import plugin
-from pyang import statements
 
 def pyang_plugin_init():
     plugin.register_plugin(XMIPlugin())

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2,7 +2,7 @@ import copy
 import re
 
 from . import util
-from .util import attrsearch, keysearch, prefix_to_module, \
+from .util import attrsearch, prefix_to_module, \
     prefix_to_modulename_and_revision
 from .error import err_add
 from . import types
@@ -1024,8 +1024,6 @@ def v_type_feature(ctx, stmt):
 
     stmt.i_is_validated = 'in_progress'
 
-    name = stmt.arg
-
     # search for circular feature definitions
     def validate_if_feature(s):
         if s.keyword == "if-feature":
@@ -1083,8 +1081,6 @@ def v_type_identity(ctx, stmt):
             return
 
     stmt.i_is_validated = 'in_progress'
-
-    name = stmt.arg
 
     # search for circular identity definitions
     def validate_base(s):

--- a/pyang/translators/xsd.py
+++ b/pyang/translators/xsd.py
@@ -285,7 +285,7 @@ def emit_xsd(ctx, module, fd):
     for m in mods:
         expand_locally_defined_typedefs(ctx, module, m)
 
-    prefixes = [module.i_xsd_prefix] + [p for p in module.i_prefixes]
+    prefixes = [module.i_xsd_prefix] + [pr for pr in module.i_prefixes]
     if module.i_xsd_prefix in ['xs', 'yin', 'nc', 'ncn']:
         i = 0
         pre = "p" + str(i)

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -1,7 +1,6 @@
 """YANG output plugin"""
 
 import optparse
-import re
 
 from .. import plugin
 from .. import util

--- a/pyang/util.py
+++ b/pyang/util.py
@@ -1,4 +1,3 @@
-import datetime
 
 from .error import err_add
 
@@ -25,24 +24,14 @@ def keysearch(tag, n, list):
     return None
 
 def dictsearch(val, dict):
-    if sys.version < '3':
-        n = dict.iteritems()
-        try:
-            while True:
-                (k,v) = n.next()
-                if v == val:
-                    return k
-        except StopIteration:
-            return None
-    else:
-        n = iter(dict.items())
-        try:
-            while True:
-                (k,v) = next(n)
-                if v == val:
-                    return k
-        except StopIteration:
-            return None
+    n = iter(dict.items())
+    try:
+        while True:
+            (k,v) = n.next()
+            if v == val:
+                return k
+    except StopIteration:
+        return None
 
 def is_prefixed(identifier):
     return type(identifier) == type(()) and len(identifier) == 2

--- a/pyang/xpath.py
+++ b/pyang/xpath.py
@@ -1,5 +1,4 @@
 import re
-import sys
 
 # not 100% XPath / XML, but good enough for YANG
 namestr=r'[a-zA-Z_][a-zA-Z0-9_\-.]*'
@@ -54,7 +53,7 @@ def validate(s):
     """Validate the XPath expression in the string `s`
     Return True if the expression is correct, and throw
     SyntaxError on failure."""
-    t = tokens(s)
+    tokens(s)
     return True
 
 def tokens(s):

--- a/pyang/yang_parser.py
+++ b/pyang/yang_parser.py
@@ -31,7 +31,7 @@ class YangTokenizer(object):
         self.pos.line += 1
         self.offset = 0
         if (self.max_line_len is not None and
-            len(unicode(self.buf, encoding="utf-8")) > self.max_line_len):
+            len(str(self.buf)) > self.max_line_len):
             error.err_add(self.errors, self.pos, 'LONG_LINE',
                           (len(self.buf), self.max_line_len))
 
@@ -42,7 +42,6 @@ class YangTokenizer(object):
     def skip(self):
         """Skip whitespace and count position"""
         i = 0
-        pos = 0
         buflen = len(self.buf)
 
         while True:
@@ -242,7 +241,7 @@ class YangParser(object):
             stmt = self._parse_statement(None)
         except error.Abort:
             return None
-        except error.Eof as e:
+        except error.Eof:
             error.err_add(self.ctx.errors, self.pos, 'EOF_ERROR', ())
             return None
         try:
@@ -297,9 +296,6 @@ class YangParser(object):
                           (keywd, tok))
             raise error.Abort
         return stmt
-
-# FIXME: tmp debug
-import sys
 
 def ppkeywd(tok):
     if util.is_prefixed(tok):

--- a/pyang/yin_parser.py
+++ b/pyang/yin_parser.py
@@ -1,9 +1,7 @@
-import sys
 from xml.parsers import expat
 import copy
 
 from . import syntax
-from . import grammar
 from . import error
 from . import statements
 from . import util

--- a/test/plugins/yangxml.py
+++ b/test/plugins/yangxml.py
@@ -94,7 +94,6 @@ def emit_leaf_list(stmt, n, fd, ind, attrs):
 def emit_list(stmt, n, fd, ind, attrs):
     while (n > 0):
         fd.write(ind + '<%s%s>\n' % (stmt.arg, attrs))
-        cs = stmt.i_children
         for k in stmt.i_key:
             fd.write(ind + '  <%s>' % k.arg)
             emit_type_val(k.search_one('type'), fd)
@@ -141,17 +140,6 @@ def emit_type_val(t, fd):
     elif statements.has_type(t, ['ipv4-address']) != None:
         fd.write('10.0.0.1')
     else:
-        length = t.search_one('length')
-        pattern = t.search('pattern')
-        if length != None:
-            # pick a length
-            (lo,hi) = pick(t.i_lengths)
-            if hi == None:
-                hi = lo
-            lentgh = randint(lo,hi)
-        if pattern != []:
-            # oh boy
-            pass
         fd.write('__foo__')
 
 def pick(xs):


### PR DESCRIPTION
pyflakes warnings were mostly about unused imports and variables.
py3kwarn reported the "unicode" usage and a iteritems one.

There was a real bug in the error reporting code of check_update.py.