### PR TITLE
Coveralls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 *.rnc
 schemas.xml
 *.pyc
+.coverage*
 /test/test_*/*.dsrl
 /test/test_*/*.rng
 /test/test_*/*.sch

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,18 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y xsltproc jing
 # }}}
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+  - SITEPACKAGES=$(pip --version | sed -n 's@.*from \([^ ]\+\) .*@\1@p')
+  - echo 'import coverage; coverage.process_startup()' > $SITEPACKAGES/sitecustomize.py
+  - printf '[run]\nparallel=True\n' > ~/coverage.cfg
 script:
   - source env.sh
+  - export COVERAGE_PROCESS_START=~/coverage.cfg
   - make test
+  - find . -name '.coverage*' -exec mv -t . {} +
+  - coverage combine
   # Test .gitignore for tests:
   - TMP=$(tempfile)
   - git ls-files . --exclude-standard --others | tee "$TMP"
@@ -29,3 +38,5 @@ script:
   # Test if we .gitignore any tracked files:
   - git ls-files -i --exclude-standard | tee "$TMP"
   - if test -s "$TMP"; then false; else true; fi
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/mbj4668/pyang.svg?branch=master)](https://travis-ci.org/mbj4668/pyang)
+[![Coverage Status](https://coveralls.io/repos/mbj4668/pyang/badge.svg)](https://coveralls.io/r/mbj4668/pyang)
 
 ## News ##
 **2014-11-18 - Version 1.5 released**


### PR DESCRIPTION
Travis now runs tests with coverage analysis enabled, and exports the
results to coveralls, where we can see the data for each file and the
historic trend.

I think you might need to create an account and/or add the repository to your list in coveralls.
