### PR TITLE
Coveralls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 *.rnc
 schemas.xml
 *.pyc
+.coverage*
 /test/test_*/*.dsrl
 /test/test_*/*.rng
 /test/test_*/*.sch

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,24 @@ python:
   # - "3.2" # error building libxml2
   # - "3.3" # error building libxml2
   # - "3.4" # error building libxml2
-# Some required packages are not yet whitelisted, this doesn't work yet:
 addons:
   apt:
     packages:
       - libxml2-dev
-      - xsltproc       # https://github.com/travis-ci/travis-ci/issues/3944
-      - jing           # https://github.com/travis-ci/travis-ci/issues/3945
-# After the issues are closed, remove the code between {{{ and }}}:
-# {{{
-sudo: true
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y xsltproc jing
-# }}}
+      - xsltproc
+      - jing
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+  - SITEPACKAGES=$(pip --version | sed -n 's@.*from \([^ ]\+\) .*@\1@p')
+  - echo 'import coverage; coverage.process_startup()' > $SITEPACKAGES/sitecustomize.py
+  - printf '[run]\nparallel=True\n' > ~/coverage.cfg
 script:
   - source env.sh
+  - export COVERAGE_PROCESS_START=~/coverage.cfg
   - make test
+  - find . -name '.coverage*' -exec mv -t . {} +
+  - coverage combine
   # Test .gitignore for tests:
   - TMP=$(tempfile)
   - git ls-files . --exclude-standard --others | tee "$TMP"
@@ -29,3 +30,5 @@ script:
   # Test if we .gitignore any tracked files:
   - git ls-files -i --exclude-standard | tee "$TMP"
   - if test -s "$TMP"; then false; else true; fi
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/mbj4668/pyang.svg?branch=master)](https://travis-ci.org/mbj4668/pyang)
+[![Coverage Status](https://coveralls.io/repos/mbj4668/pyang/badge.svg)](https://coveralls.io/r/mbj4668/pyang)
 
 ## News ##
 **2014-11-18 - Version 1.5 released**


### PR DESCRIPTION
- Fix compatibility issues with python 3 - travis now run tests with python 2.7, 3.2, 3.3 and 3.4.
- Fixed warnings from pyflakes and py3kwarn static analysers. Added them to travis.
- Added coveralls test coverage report, with badge.

More details are in the messages from the individual commits.

Sorry for the pull-request confusion. I tried to create individual changes, but they turned out to be incompatible, conflicting with one another. This pull request has all changes, and passes all tests.