### PR TITLE
creating output directory

### DIFF
--- a/bin/pyang
+++ b/bin/pyang
@@ -391,6 +391,8 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                 fd = sys.stdout
         else:
             tmpfile = o.outfile + ".tmp"
+            if not os.path.exists(os.path.dirname(tmpfile)):
+                os.makedirs(os.path.dirname(tmpfile))
             if sys.version < '3':
                 fd = codecs.open(tmpfile, "w+", encoding="utf-8")
             else:

--- a/bin/pyang
+++ b/bin/pyang
@@ -391,7 +391,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                 fd = sys.stdout
         else:
             tmpfile = o.outfile + ".tmp"
-            if not os.path.exists(os.path.dirname(tmpfile)):
+            if not os.path.exists(os.path.dirname(os.path.abspath(tmpfile))):
                 os.makedirs(os.path.dirname(tmpfile))
             if sys.version < '3':
                 fd = codecs.open(tmpfile, "w+", encoding="utf-8")


### PR DESCRIPTION
If the user didn't created output directory to redirect pyang output using --output option, pyang will return IOError: [Errno 2] No such file or directory.