### PR TITLE
Print '?' for non-mandatory anyxml.

### DIFF
--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -229,7 +229,8 @@ def print_node(s, module, fd, prefix, path, mode, depth, width):
     else:
         if s.keyword == 'leaf-list':
             name += '*'
-        elif s.keyword == 'leaf' and not hasattr(s, 'i_is_key'):
+        elif (s.keyword == 'leaf' and not hasattr(s, 'i_is_key')
+            or s.keyword == 'anyxml'):
             m = s.search_one('mandatory')
             if m is None or m.arg == 'false':
                 name += '?'

--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -78,7 +78,7 @@ Each node is printed as:
    name is printed as <prefix>:<name>.
 
   <opts> is one of:
-    ?  for an optional leaf or choice
+    ?  for an optional leaf, choice or anyxml
     !  for a presence container
     *  for a leaf-list or list
     [<keys>] for a list's keys


### PR DESCRIPTION
anyxml can have the mandatory substatement, so in the tree output it probably makes sense to print '?' next to anyxml nodes that aren't mandatory.

If you agree, I can merge the tree-anyxml branch with master.

The same should be done in yang-1.1 branch also for anydata.