### PR TITLE
remove automatic installation of bash completions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,5 @@ setup(name='pyang',
             ('share/yang/xslt', xslt),
             ('share/yang/images', images),
             ('share/yang/schema', schema),
-            ('etc/bash_completion.d', ['etc/bash_completion.d/pyang']),
             ]
       )


### PR DESCRIPTION
This is line in the setup.py was causing problems with our older CentOS build agents that don't have root access when installing pyang as part of the build process.  Also, got errors that file doesn't exist.