### PR TITLE
add netconf namespace validation for message-id

### DIFF
--- a/schema/relaxng-lib.rng
+++ b/schema/relaxng-lib.rng
@@ -41,7 +41,7 @@
   </define>
 
   <define name="message-id-attribute">
-    <attribute name="message-id">
+    <attribute name="nc:message-id">
       <data type="string">
 	<param name="maxLength">4095</param>
       </data>

--- a/test/test_dsdl/ll-2mod-get-reply.xml
+++ b/test/test_dsdl/ll-2mod-get-reply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<nc:rpc-reply message-id="132"
+<nc:rpc-reply nc:message-id="132"
 	      xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
 <nc:data xmlns="http://example.com/ll/2mod-a"
 	 xmlns:tb="http://example.com/ll/2mod-b">

--- a/test/test_dsdl/ll-2mod-rpc.xml
+++ b/test/test_dsdl/ll-2mod-rpc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <rock-the-house xmlns="http://example.com/ll/2mod-a">
     <zip>12345-6789</zip>
     <magnitude xmlns="http://example.com/ll/2mod-b">7.2</magnitude>

--- a/test/test_dsdl/ll-choice-get-reply.xml
+++ b/test/test_dsdl/ll-choice-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/choice">
     <cont-1>
       <leaf-3>false</leaf-3>

--- a/test/test_dsdl/ll-cont-get-reply.xml
+++ b/test/test_dsdl/ll-cont-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/cont">
     <cont-1>
       <cont-3>

--- a/test/test_dsdl/ll-grinrpc-get-reply.xml
+++ b/test/test_dsdl/ll-grinrpc-get-reply.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <nc:rpc-reply xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
-	      message-id="142">
+	      nc:message-id="142">
   <nc:data xmlns="http://example.com/ll/grinrpc">
     <cont-1>
       <list-1>

--- a/test/test_dsdl/ll-grinrpc-rpc-reply.xml
+++ b/test/test_dsdl/ll-grinrpc-rpc-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101"
+<nc:rpc-reply nc:message-id="101"
 	      xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:ok/>
 </nc:rpc-reply>

--- a/test/test_dsdl/ll-grinrpc-rpc.xml
+++ b/test/test_dsdl/ll-grinrpc-rpc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc message-id="101"
+<nc:rpc nc:message-id="101"
 	xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <rpc-1 xmlns="http://example.com/ll/grinrpc">
     <list-1>

--- a/test/test_dsdl/ll-impl-get-reply.xml
+++ b/test/test_dsdl/ll-impl-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/impl">
     <cont-1>
       <cont-3>

--- a/test/test_dsdl/ll-leaf-get-config-reply.xml
+++ b/test/test_dsdl/ll-leaf-get-config-reply.xml
@@ -3,7 +3,7 @@
 
 <nc:rpc-reply xmlns:le="http://example.com/ll/leaf"
 	      xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
-	      message-id="142">
+	      nc:message-id="142">
   <nc:data>
     <le:leaf-2>2.71</le:leaf-2>
     <le:leaf-1>foo</le:leaf-1>

--- a/test/test_dsdl/ll-leaf-get-reply.xml
+++ b/test/test_dsdl/ll-leaf-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="6378"
+<nc:rpc-reply nc:message-id="6378"
 	      xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/leaf">
     <leaf-2>2.71</leaf-2>

--- a/test/test_dsdl/ll-leafref-get-reply.xml
+++ b/test/test_dsdl/ll-leafref-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/leafref">
     <seq><clef>foo</clef></seq>
     <seq><clef>bar</clef></seq>

--- a/test/test_dsdl/ll-list-get-reply.xml
+++ b/test/test_dsdl/ll-list-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/list">
     <list-1>
       <leaf-1>true</leaf-1>

--- a/test/test_dsdl/ll-obu-edit-config.xml
+++ b/test/test_dsdl/ll-obu-edit-config.xml
@@ -3,7 +3,7 @@
 <nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
 	xmlns:yang="urn:ietf:params:xml:ns:yang:1"
 	xmlns="http://example.com/ll/obu"
-	message-id="42">
+	nc:message-id="42">
   <nc:edit-config>
     <nc:target>
       <nc:running/>

--- a/test/test_dsdl/ll-refaug-get-reply.xml
+++ b/test/test_dsdl/ll-refaug-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/refaug">
     <list-1>
       <leaf-2>true</leaf-2>

--- a/test/test_dsdl/ll-rpcnot-get-reply.xml
+++ b/test/test_dsdl/ll-rpcnot-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/rpcnot">
     <cont-1>
       <leaf-1>42</leaf-1>

--- a/test/test_dsdl/ll-rpcnot-rpc-reply.xml
+++ b/test/test_dsdl/ll-rpcnot-rpc-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101"
+<nc:rpc-reply nc:message-id="101"
 	      xmlns="http://example.com/ll/rpcnot"
 	      xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <leaf-6>false</leaf-6>

--- a/test/test_dsdl/ll-rpcnot-rpc.xml
+++ b/test/test_dsdl/ll-rpcnot-rpc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <rpc-1 xmlns="http://example.com/ll/rpcnot">
     <list-1>
       <leaf-4>foo</leaf-4>

--- a/test/test_dsdl/ll-typgr-get-reply.xml
+++ b/test/test_dsdl/ll-typgr-get-reply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<nc:rpc-reply message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<nc:rpc-reply nc:message-id="101" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
   <nc:data xmlns="http://example.com/ll/typgr">
     <cont-1>
       <leaf-3>2</leaf-3>


### PR DESCRIPTION
Check namespace for message-id for case:
```
<rfc6020:rpc xmlns:rfc6020="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns="http://example.net/turing-machine" rfc6020:message-id="93449">
  <initialize>
    <tape-content>101010101</tape-content>
  </initialize>
</rfc6020:rpc>
```

Change checked with turring machine with code from https://github.com/cloudify-cosmo/cloudify-netconf-plugin.