### PR TITLE
Improve default implicit `$YANG_MODPATH` discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ MANIFEST.in
 TAGS
 build
 dist
+pyang.egg-info  # created during build
+.cache  # created during build
+.python-version
 *.rnc
 schemas.xml
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ addons:
     packages:
       - xsltproc
       - jing
+      - bash
 install:
   - pip install -r requirements.txt
-  - pip install coveralls
+  - pip install coveralls virtualenv
   - SITEPACKAGES=$(pip --version | sed -n 's@.*from \([^ ]\+\) .*@\1@p')
   - echo 'import coverage; coverage.process_startup()' > $SITEPACKAGES/sitecustomize.py
   - printf '[run]\nparallel=True\n' > ~/coverage.cfg

--- a/test/test_issues/Makefile
+++ b/test/test_issues/Makefile
@@ -1,0 +1,10 @@
+DIRS = $(shell for d in test_* ; \
+	do [ -d $$d -a -f $$d/Makefile ] && echo $$d ; done)
+
+test: subdirs
+
+subdirs:
+	for d in $(DIRS); do 						\
+		( cd $$d && $(MAKE) test ) || exit 1;			\
+	done
+

--- a/test/test_issues/test_i225/Makefile
+++ b/test/test_issues/test_i225/Makefile
@@ -1,0 +1,4 @@
+test:
+	# it is not possible to run 'source' from Makefile,
+	# since it is required for virtualenv, call a bash script
+	bash test.sh

--- a/test/test_issues/test_i225/test.sh
+++ b/test/test_issues/test_i225/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# since virtualenv manipulates env vars it is better to keep all
+# the dependent tasks runing inside a single process.
+
+## setup ---------------------------------------------------------------------
+# install virtualenv
+[ -d .test-env ] || \
+    virtualenv --system-site-packages --always-copy .test-env > /dev/null
+# activate it
+source .test-env/bin/activate
+# Install pytest
+pip install pytest > /dev/null
+# Build pyang from source and install it using pip
+current_dir=$PWD
+cd ../../..
+rm -f dist/*.whl
+python setup.py bdist_wheel > /dev/null
+pip install -I dist/*.whl > /dev/null
+cd $current_dir
+
+## tests ---------------------------------------------------------------------
+py.test test_*.py
+
+## teardown ------------------------------------------------------------------
+# deactivate virtualenv
+deactivate
+# remove it
+rm -Rf .test-env
+# cleanup build
+cd ../../..
+rm -Rf pyang.egg-info .cache build/*.whl
+cd $current_dir

--- a/test/test_issues/test_i225/test_prefix_deviation.py
+++ b/test/test_issues/test_i225/test_prefix_deviation.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""
+tests for PYANG data files
+"""
+import os
+import sys
+from os.path import abspath, dirname
+
+import pip
+
+from pyang import Context, FileRepository
+
+EXISTING_MODULE = 'ietf-yang-types'
+
+DEFAULT_OPTIONS = {
+    'format': 'yang',
+    'verbose': True,
+    'list_errors': True,
+    'print_error_code': True,
+    'yang_remove_unused_imports': True,
+    'yang_canonical': True,
+    'trim_yin': False,
+    'keep_comments': True,
+    'features': [],
+    'deviations': [],
+    'path': []
+}
+"""Default options for pyang command line"""
+
+
+class objectify(object):
+    """Utility for providing object access syntax (.attr) to dicts"""
+
+    def __init__(self, *args, **kwargs):
+        for entry in args:
+            self.__dict__.update(entry)
+
+        self.__dict__.update(kwargs)
+
+    def __getattr__(self, _):
+        return None
+
+    def __setattr__(self, attr, value):
+        self.__dict__[attr] = value
+
+
+def create_context(path='.', *options, **kwargs):
+    """Generates a pyang context
+
+    Arguments:
+        path (str): location of YANG modules.
+        *options: list of dicts, with options to be passed to context.
+        **kwargs: similar to ``options`` but have a higher precedence.
+
+    Returns:
+        pyang.Context: Context object for ``pyang`` usage
+    """
+
+    opts = objectify(DEFAULT_OPTIONS, *options, **kwargs)
+    repo = FileRepository(path, no_path_recurse=opts.no_path_recurse)
+    ctx = Context(repo)
+    ctx.opts = opts
+
+    return ctx
+
+
+def test_can_find_modules_with_pip_install():
+    """
+    context should find the default installed modules even when pyang
+        is installed using pip
+    """
+
+    # remove obfuscation from env vars
+    if os.environ.get('YANG_INSTALL'):
+        del os.environ['YANG_INSTALL']
+
+    if os.environ.get('YANG_MODPATH'):
+        del os.environ['YANG_MODPATH']
+
+    ctx = create_context()
+    module = ctx.search_module(None, EXISTING_MODULE)
+    assert module is not None
+
+
+def test_can_find_modules_when_prefix_differ(monkeypatch):
+    """
+    context should find the default installed modules, without the help
+        of environment variables, even of the pip install location
+        differs from ``sys.prefix``
+    """
+
+    # store pip location.
+    # monkeypatching sys.prefix will side_effect scheme.
+    scheme = pip.locations.distutils_scheme('pyang')
+    monkeypatch.setattr(
+        pip.locations, 'distutils_scheme', lambda *_: scheme)
+
+    # simulate #225 description
+    monkeypatch.setattr(sys, 'prefix', '/usr')
+
+    # remove obfuscation from env vars
+    if os.environ.get('YANG_INSTALL'):
+        del os.environ['YANG_INSTALL']
+
+    if os.environ.get('YANG_MODPATH'):
+        del os.environ['YANG_MODPATH']
+
+    ctx = create_context()
+    module = ctx.search_module(None, EXISTING_MODULE)
+    assert module is not None


### PR DESCRIPTION
For some systems `sys.prefix` is `/usr`, but python packages are installed in `/usr/local` by pip, as reported in #225.

With this change, pyang first tries the default location, and if it does not exist, asks  pip for the right one.
