### PR TITLE
Fix #230 by calling split directly

### DIFF
--- a/pyang/plugin.py
+++ b/pyang/plugin.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import string
 
 plugins = []
 """List of registered PyangPlugin instances"""
@@ -23,7 +22,7 @@ def init(plugindirs=[]):
     # add paths from env
     pluginpath = os.getenv('PYANG_PLUGINPATH')
     if pluginpath is not None:
-        plugindirs.extend(string.split(pluginpath, os.pathsep))
+        plugindirs.extend(pluginpath.split(os.pathsep))
 
     syspath = sys.path
     for plugindir in plugindirs:

--- a/pyang/plugins/omni.py
+++ b/pyang/plugins/omni.py
@@ -2,7 +2,6 @@
 import optparse
 import sys
 import re
-import string
 
 from pyang import plugin
 from pyang import statements
@@ -41,7 +40,7 @@ class OmniPlugin(plugin.PyangPlugin):
 
     def emit(self, ctx, modules, fd):
         if ctx.opts.omni_tree_path is not None:
-            path = string.split(ctx.opts.omn_tree_path, '/')
+            path = ctx.opts.omni_tree_path.split('/')
             if path[0] == '':
                 path = path[1:]
         else:

--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -6,7 +6,6 @@ Idea copied from libsmi.
 import optparse
 import sys
 import re
-import string
 
 from pyang import plugin
 from pyang import statements
@@ -50,7 +49,7 @@ class TreePlugin(plugin.PyangPlugin):
 
     def emit(self, ctx, modules, fd):
         if ctx.opts.tree_path is not None:
-            path = string.split(ctx.opts.tree_path, '/')
+            path = ctx.opts.tree_path.split('/')
             if path[0] == '':
                 path = path[1:]
         else:

--- a/test/test_issues/Makefile
+++ b/test/test_issues/Makefile
@@ -1,0 +1,10 @@
+DIRS = $(shell for d in test_* ; \
+	do [ -d $$d -a -f $$d/Makefile ] && echo $$d ; done)
+
+test: subdirs
+
+subdirs:
+	for d in $(DIRS); do 						\
+		( cd $$d && $(MAKE) test ) || exit 1;			\
+	done
+

--- a/test/test_issues/test_i230/Makefile
+++ b/test/test_issues/test_i230/Makefile
@@ -1,0 +1,9 @@
+test:
+	PYANG_PLUGINPATH=. pyang -f yin example-sports.yang \
+			 -o example-sports.yin
+	pyang -f tree --tree-path=sports/person/name example-sports.yang \
+		-o example-sports.tree
+	pyang -f omni --omni-path=sports/person/name example-sports.yang \
+		-o example-sports.omni
+	rm -f *.yin *.tree *.omni
+

--- a/test/test_issues/test_i230/example-sports.yang
+++ b/test/test_issues/test_i230/example-sports.yang
@@ -1,0 +1,22 @@
+module example-sports {
+  namespace "http://example.com/example-sports";
+  prefix sports;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  container sports {
+    config true;
+    list person {
+      key "name";
+      leaf name {
+        type string;
+      }
+      leaf birthday {
+        type yang:date-and-time;
+        mandatory true;
+      }
+    }
+  }
+}


### PR DESCRIPTION
As reported in #230 `string.split` was removed from python, and this makes pyang crash on python 3.

- Proposed solution:
  * avoid using deprecated functions from `string` module, call functions directly on string object instead.
- Drawbacks:
  * older versions of python may crash
- Advantages:
  * works on python 3