### PR TITLE
Prevent importing temporary Emacs files

### DIFF
--- a/pyang/plugin.py
+++ b/pyang/plugin.py
@@ -32,7 +32,8 @@ def init(plugindirs=[]):
         except OSError:
             continue
         for fname in fnames:
-            if fname.endswith(".py") and fname != '__init__.py':
+            if not fname.startswith(".#") and fname.endswith(".py") and \
+               fname != '__init__.py':
                 pluginmod = __import__(fname[:-3])
                 try:
                     pluginmod.pyang_plugin_init()


### PR DESCRIPTION
i.e. files whose names are of the form `.#xxx.py`.

Please let me know if you'd like an example that demonstrates the problem.