### PR TITLE
Work around spectral if feature statements

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2684,8 +2684,11 @@ class Statement(object):
         """pointer to the top-level Statement"""
 
         self.parent = parent
+        self.real_parent = parent
         """pointer to the parent Statement"""
 
+        self.pos_begin = copy.copy(pos)
+        self.pos_end = copy.copy(pos)
         self.pos = copy.copy(pos)
         """position in input stream, for error reporting"""
         if self.pos is not None and self.pos.top is None:

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -1699,10 +1699,13 @@ def v_expand_2_augment(ctx, stmt):
             c.parent = stmt.i_target_node
             v_inherit_properties(ctx, stmt.i_target_node, c)
     if_features = stmt.search('if-feature')
+    # XXX these additional child if-feature statements cause problems for
+    #     output formats, so mark them to make it easy to ignore them
     for s in stmt.substmts:
         for f in if_features:
-            s.substmts.append(Statement(f.top, stmt.parent, f.pos, f.keyword,
-                                        f.arg))
+            c = Statement(f.top, stmt.parent, f.pos, f.keyword, f.arg)
+            c._ignored_by_output_format_ = True
+            s.substmts.append(c)
         if s.keyword in _copy_augment_keywords:
             stmt.i_target_node.substmts.append(s)
             s.parent = stmt.i_target_node

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -125,14 +125,18 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd_class, next_stmt,
         else:
             emit_arg(stmt, fd, indent, indentstep)
 
-    if len(stmt.substmts) == 0:
+    # XXX see statements.py
+    substmts = [s for s in stmt.substmts
+                if not hasattr(s, "_ignored_by_output_format_")]
+    
+    if len(substmts) == 0:
         fd.write(';' + stmt_term)
     else:
         fd.write(' {\n')
         if ctx.opts.yang_canonical:
-            substmts = grammar.sort_canonical(stmt.keyword, stmt.substmts)
-        else:
-            substmts = stmt.substmts
+            substmts = grammar.sort_canonical(stmt.keyword, substmts)
+        #else:
+        #    substmts = stmt.substmts
         if level == 0:
             kwd_class = 'header'
         for (i, s) in enumerate(substmts):


### PR DESCRIPTION
I didn't investigate this fully, but the parse tree validation appears to add `if-feature` statements that weren't in the original YANG. This causes problems with output formats that will process such statements.

The workaround simply marks these "spectral" `if-feature` statements and adds code to the `yang` output format to prevent their use.

This pull request is based on the `yang-parse` pull request #244 because otherwise there's a minor conflict. Please let me know if you'd like a pull request based on master, or if you'd like an example that demonstrates the problem.
