### PR TITLE
Check a submodule's parent for a grouping if not local

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2303,7 +2303,12 @@ def search_grouping(stmt, name):
                 if mod.search_one('include', g.i_orig_module.arg) is None:
                     return None
             return g
-        stmt = stmt.parent
+        if stmt.keyword == 'submodule':
+          # find the parent module of the submodule to
+          # check whether it has this grouping
+          stmt = stmt.i_ctx.modules[(stmt.search_one('belongs-to').arg, 'unknown')]
+        else:
+          stmt = stmt.parent
     return None
 
 def search_data_keyword_child(children, modulename, identifier):


### PR DESCRIPTION
**Commits**:

```  
* (M) pyang/statements:
    - If a grouping is not found within a submodule, check whether
      it is present within the parent module (which is not
      explicitly included).
```

**Description:**

When a grouping is defined with a parent module, and then used within a submodule, the parent is never checked for the grouping (since the `.parent` attribute of the submodule does not refer to the parent module).  RFC 7950 Section 5.1 says:

```
   o  A module, or submodule belonging to that module, MAY reference
      definitions in the module and all submodules included by the
      module.
```

So I believe that this isn't correct. This patch checks whether the statement that is examined when walking back up the tree is a submodule statement, and if so, finds the main module.

Currently, the approach taken here uses the context plus module name, because we don't seem to be far enough through validation to simply call `stmt.main_module()`.

I didn't add a test-case, but here's two YANG files that demonstrate this:

```yang
 module parent {
  prefix "p";
  namespace "http://google.com/p";

  include child;

  grouping parent-foo {
    leaf bork { type boolean; }
  }
}
```

```
submodule child {
  belongs-to parent {
    prefix "p";
  }

  uses parent-foo;
}
```

In pyang 1.7 this will report `parent-foo` as an unknown grouping prior to this patch.