### PR TITLE
Include data files in source distribution tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 MANIFEST
-MANIFEST.in
 TAGS
 build
 dist
 *.rnc
 schemas.xml
 *.pyc
+*.egg-info
 .coverage*
 /test/test_*/*.dsrl
 /test/test_*/*.rng

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include etc/bash_completion.d/pyang
+recursive-include modules *
+recursive-include xslt *
+recursive-include schema *
+recursive-include tools/images *
+recursive-include man *
+include LICENSE
+include env.sh

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,10 @@
 # create a full source package
-sdist: MANIFEST doc
-	rm -f MANIFEST.in
+sdist: doc
 	python setup.py sdist
 	-# mv dist/pyang-*.tar.gz dist/pyang_src-*.tar.gz
 
 # create a minimal package
 dist: doc
-	rm -f MANIFEST
-	echo "include LICENSE" > MANIFEST.in
-	echo "include env.sh" >> MANIFEST.in
-	echo "recursive-include man *" >> MANIFEST.in
-	echo "recursive-include schema *" >> MANIFEST.in
-	echo "recursive-include xslt *" >> MANIFEST.in
-	echo "recursive-include modules *" >> MANIFEST.in
-	echo "recursive-include tools/images *" >> MANIFEST.in
 	python setup.py sdist
 
 .PHONY:	test tags clean doc
@@ -27,17 +18,8 @@ clean:
 	(cd test && $(MAKE) clean)
 	(cd doc &&  $(MAKE) clean)
 	python setup.py clean --all
-	rm -rf build dist MANIFEST*
+	rm -rf build dist MANIFEST
 	find . -name "*.pyc" -exec rm {} \;
-
-MANIFEST:
-	@if [ -d .svn ] ; then \
-	    svn list -R | grep -v ".gitignore" > $@; \
-	elif [ -d .git ] ; then \
-	    git ls-files > $@; \
-	else \
-	    echo "MANIFEST can only be generated from SVN or git."; \
-	fi
 
 tags:
 	find . -name "*.py" | etags -


### PR DESCRIPTION
1. Added `MANIFEST.in` file and included data files to it. In absence of `MANIFEST.in` data files are not included in source tarball. This makes pip to fail when installing from source tarball.

2. Removed `MANIFEST.in` creation from `Makefile`