### PR TITLE
Correct sentence in --tree-help output.

### DIFF
--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -94,7 +94,7 @@ Each node is printed as:
   <type> is the name of the type for leafs and leaf-lists
 
     If the type is a leafref, the type is printed as "-> TARGET", where
-    TARGET is either the leafref path, with prefixed removed if possible.
+    TARGET is the leafref path, with prefix removed if possible.
 
   <if-features> is the list of features this node depends on, printed
     within curly brackets and a question mark "{...}?"


### PR DESCRIPTION
The output from pyang --tree-help looks strange for leafref types. Suggesting what I think it should be.