### PR TITLE
Addressing https://github.com/mbj4668/pyang/issues/320

### DIFF
--- a/bin/pyang
+++ b/bin/pyang
@@ -154,6 +154,10 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                              action="store_true",
                              help="Do not recurse into directories in the \
                                    yang path."),
+        optparse.make_option("--ensure-hyphenated-names",
+                             dest="ensure_hyphenated_names",
+                             action="store_true",
+                             help="No upper case and underscore in names."),
         ]
 
     optparser = optparse.OptionParser(usage, add_help_option = False)
@@ -228,6 +232,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
     ctx.lax_xpath_checks = o.lax_xpath_checks
     ctx.lax_quote_checks = o.lax_quote_checks
     ctx.strict = o.strict
+    ctx.ensure_hyphenated_names = o.ensure_hyphenated_names
 
     # make a map of features to support, per module
     if o.hello:

--- a/etc/bash_completion.d/pyang
+++ b/etc/bash_completion.d/pyang
@@ -34,7 +34,8 @@ _pyang()
         --check-update-from
         -P --check-update-from-path
         --ietf
-        --lint"
+        --lint
+        --ensure-hyphenated-names"
 
     local opts_capability="--capability-entity"
 

--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -43,6 +43,7 @@ class Context(object):
         self.deviation_modules = []
         self.features = {}
         self.keep_comments = False
+        self.ensure_hyphenated_names = False
 
         for mod, rev, handle in self.repository.get_modules_and_revisions(self):
             if mod not in self.revs:

--- a/pyang/error.py
+++ b/pyang/error.py
@@ -459,6 +459,9 @@ error_codes = \
     'STRICT_XPATH_FUNCTION':
       (2,
        'XPath function "%s" is not allowed for strict YANG compliance'),
+    'NOT_HYPHENATED':
+      (4,
+       'name is not hyphenated, e.g using upper-case or underscore: %s'),
     }
 
 def add_error_code(tag, level, fmt):

--- a/pyang/grammar.py
+++ b/pyang/grammar.py
@@ -656,6 +656,12 @@ def _chk_stmts(ctx, pos, stmts, parent, spec, canonical):
                               (stmt.arg, ctx.max_identifier_len))
                 # recoverable error
                 stmt.is_grammatically_valid = True
+            elif ((arg_type == 'identifier' or arg_type == 'enum-arg') and
+                  ctx.ensure_hyphenated_names
+                  and util.not_hyphenated(stmt.arg)):
+                error.err_add(ctx.errors, stmt.pos, 'NOT_HYPHENATED', stmt.arg)
+                # recoverable error
+                stmt.is_grammatically_valid = True                
             else:
                 stmt.is_grammatically_valid = True
 

--- a/pyang/plugins/lint.py
+++ b/pyang/plugins/lint.py
@@ -70,7 +70,6 @@ class LintPlugin(plugin.PyangPlugin):
         ctx.canonical = True
         ctx.max_identifier_len = 64
         ctx.implicit_errors = False
-        ctx.ensure_hyphenated_names = True
 
         # always add additional prefixes given on the command line
         self.namespace_prefixes.extend(ctx.opts.lint_namespace_prefixes)

--- a/pyang/plugins/lint.py
+++ b/pyang/plugins/lint.py
@@ -70,6 +70,7 @@ class LintPlugin(plugin.PyangPlugin):
         ctx.canonical = True
         ctx.max_identifier_len = 64
         ctx.implicit_errors = False
+        ctx.ensure_hyphenated_names = True
 
         # always add additional prefixes given on the command line
         self.namespace_prefixes.extend(ctx.opts.lint_namespace_prefixes)

--- a/pyang/util.py
+++ b/pyang/util.py
@@ -133,3 +133,10 @@ def unique_prefixes(context):
             new = "%s%x" % (prf, suff)
         res[m] = new
     return res
+
+def not_hyphenated(name):
+    ''' Returns True if name is not hyphenated '''
+    if name == None:
+        return False
+    # Check for upper-case and underscore
+    return (name != name.lower() or "_" in name)


### PR DESCRIPTION
- Added --ensure-hyphentaed-names to catch identifiers/enum-args
  which use camel-case or underscore
- Changed method _setup_ctx of class LintPlugin() to set
  ensure_hyphenated_names to True. Since IETFPlugin() is a child
  class of LintPlugin(), option --ietf will detect use of
  camel-case or underscore