### PR TITLE
Avoid misinterpreting malformed filenames

### DIFF
--- a/bin/pyang
+++ b/bin/pyang
@@ -13,6 +13,7 @@ from pyang import plugin
 from pyang import error
 from pyang import util
 from pyang import hello
+from pyang import syntax
 
 def run():
 
@@ -293,7 +294,6 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
             sys.stderr.write("too many files to convert\n")
             sys.exit(1)
 
-        r = re.compile(r"^(.*?)(\@(\d{4}-\d{2}-\d{2}))?\.(yang|yin)$")
         for filename in filenames:
             try:
                 fd = io.open(filename, "r", encoding="utf-8")
@@ -305,10 +305,10 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                 s = str(ex).replace('utf-8', 'utf8')
                 sys.stderr.write("%s: unicode error: %s\n" % (filename, s))
                 sys.exit(1)
-            m = r.search(filename)
+            m = syntax.re_filename.search(filename)
             ctx.yin_module_map = {}
             if m is not None:
-                (name, _dummy, rev, format) = m.groups()
+                (name, rev, format) = m.groups()
                 name = os.path.basename(name)
                 module = ctx.add_module(filename, text, format, name, rev,
                                         expect_failure_error=False)

--- a/pyang/error.py
+++ b/pyang/error.py
@@ -125,12 +125,18 @@ error_codes = \
     'WBAD_MODULE_NAME':
       (4,
        'unexpected modulename "%s" in %s, should be %s'),
+    'FILENAME_BAD_MODULE_NAME':
+      (4,
+       'filename "%s" suggests invalid module name "%s", should match "%s"'),
     'BAD_REVISION':
       (3,
        'unexpected latest revision "%s" in %s, should be %s'),
     'WBAD_REVISION':
       (4,
        'unexpected latest revision "%s" in %s, should be %s'),
+    'FILENAME_BAD_REVISION':
+      (4,
+       'filename "%s" suggests invalid revision "%s", should match "%s"'),
     'BAD_SUB_BELONGS_TO':
       (1,
        'module %s includes %s, but %s does not specify a correct belongs-to'),

--- a/pyang/syntax.py
+++ b/pyang/syntax.py
@@ -125,6 +125,12 @@ re_absolute_schema_nodeid = re.compile("^" + absolute_schema_nodeid + "$")
 re_descendant_schema_nodeid = re.compile("^" + descendant_schema_nodeid + "$")
 re_deviate = re.compile("^(add|delete|replace|not-supported)$")
 
+# Not part of YANG syntax per se but useful for pyang in several places
+re_filename = re.compile(r"^([^@]*?)" +          # putative module name
+                         r"(?:@([^.]*?))?" +     # putative revision
+                         r"(?:\.yang|\.yin)*" +  # foo@bar.yang.yin.yang.yin ?
+                         r"\.(yang|yin)$")       # actual final extension
+
 arg_type_map = {
     "identifier": lambda s: re_identifier.search(s) is not None,
     "non-negative-integer": lambda s: re_nonneg_integer.search(s) is not None,

--- a/test/test_bad/1@2.yang
+++ b/test/test_bad/1@2.yang
@@ -1,0 +1,8 @@
+module one {
+    namespace 'urn:one';
+
+    prefix 'one';
+
+    revision 2002-02-02 {
+    }
+}

--- a/test/test_bad/@2017-09-26.yang
+++ b/test/test_bad/@2017-09-26.yang
@@ -1,0 +1,6 @@
+module noname {
+    namespace "urn:noname";
+    prefix "noname";
+    revision 2017-09-26 {
+    }
+}

--- a/test/test_bad/badrev@2017-09.yang
+++ b/test/test_bad/badrev@2017-09.yang
@@ -1,0 +1,5 @@
+module badrev {
+    namespace 'urn:badrev';
+
+    prefix 'badrev';
+}

--- a/test/test_bad/expect/1@2.yang.out
+++ b/test/test_bad/expect/1@2.yang.out
@@ -1,0 +1,2 @@
+1@2.yang:1: warning: FILENAME_BAD_MODULE_NAME
+1@2.yang:1: warning: FILENAME_BAD_REVISION

--- a/test/test_bad/expect/@2017-09-26.yang.out
+++ b/test/test_bad/expect/@2017-09-26.yang.out
@@ -1,0 +1,1 @@
+@2017-09-26.yang:1: warning: FILENAME_BAD_MODULE_NAME

--- a/test/test_bad/expect/badrev@2017-09.yang.out
+++ b/test/test_bad/expect/badrev@2017-09.yang.out
@@ -1,0 +1,1 @@
+badrev@2017-09.yang:1: warning: FILENAME_BAD_REVISION

--- a/test/test_bad/expect/norev@.yang.out
+++ b/test/test_bad/expect/norev@.yang.out
@@ -1,0 +1,1 @@
+norev@.yang:1: warning: FILENAME_BAD_REVISION

--- a/test/test_bad/norev@.yang
+++ b/test/test_bad/norev@.yang
@@ -1,0 +1,6 @@
+module norev {
+    namespace "urn:norev";
+    prefix "norev";
+    revision 2017-09-26 {
+    }
+}


### PR DESCRIPTION
Currently pyang is picky about the revision date in the filename (`r"\@(\d{4}-\d{2}-\d{2})"`) but not the module name (`r"^(.*?)"`) This means that file names with a misconstructed revision date get misinterpreted by pyang as having the revision date as part of the expected module name, e.g.:

```
pyang 'foo@2011-01-0.yang'
foo@2011-01-0.yang:1: warning: unexpected modulename "foo" in foo@2011-01-0.yang, should be foo@2011-01-0
```

This PR fixes the issue by making the module-name part of the filename match as equally picky as the revision part.