### PR TITLE
mk_path_str: respect with_prefixes for choice/case statements

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2882,7 +2882,7 @@ def print_tree(stmt, substmts=True, i_children=True, indent=0):
 def mk_path_str(s, with_prefixes=False):
     """Returns the XPath path of the node"""
     if s.keyword in ['choice', 'case']:
-        return mk_path_str(s.parent)
+        return mk_path_str(s.parent, with_prefixes)
     def name(s):
         if with_prefixes:
             return s.i_module.i_prefix + ":" + s.arg


### PR DESCRIPTION
### Problem

The `mk_path_str` function loses track of the `with_prefixes` option when it encounters a `choice` or `case` statement, resulting in mis-formed strings like `"/get-config/input/source/nc:candidate"` (ietf-netconf.yang). 

### Solution: 

Pass through the `with_prefixes` option even in this special case.