### PR TITLE
Save the original pattern regexps in the typespec

### DIFF
--- a/pyang/types.py
+++ b/pyang/types.py
@@ -491,7 +491,7 @@ def validate_pattern_expr(errors, stmt):
     if res is not False:
         return res
     # Otherwise we can't validate patterns :(
-    return None
+    return ('skip', None, stmt.pos, invert_match, stmt.arg)
 
 class PatternTypeSpec(TypeSpec):
     def __init__(self, base, pattern_specs):
@@ -512,6 +512,8 @@ class PatternTypeSpec(TypeSpec):
                 import lxml
                 doc = StringIO('<a>%s</a>' % escape(val))
                 is_valid = re.validate(lxml.etree.parse(doc))
+            elif type_ == 'skip':
+                continue # can't validate patterns
             if ((not is_valid and not invert_match) or
                 (is_valid and invert_match)):
                 err_add(errors, pos, 'TYPE_VALUE',

--- a/pyang/types.py
+++ b/pyang/types.py
@@ -444,7 +444,7 @@ def _validate_pattern_libxml2(errors, stmt, invert_match):
         import libxml2
         try:
             re = libxml2.regexpCompile(stmt.arg)
-            return ('libxml2', re, stmt.pos, invert_match)
+            return ('libxml2', re, stmt.pos, invert_match, stmt.arg)
         except libxml2.treeError as v:
             err_add(errors, stmt.pos, 'PATTERN_ERROR', str(v))
             return None
@@ -470,7 +470,7 @@ def _validate_pattern_lxml(errors, stmt, invert_match):
             '   </xsd:schema>' % quoteattr(stmt.arg))
         try:
             sch = lxml.etree.XMLSchema(lxml.etree.parse(doc))
-            return ('lxml', sch, stmt.pos, invert_match)
+            return ('lxml', sch, stmt.pos, invert_match, stmt.arg)
         except lxml.etree.XMLSchemaParseError as v:
             err_add(errors, stmt.pos, 'PATTERN_ERROR', str(v))
             return None
@@ -505,7 +505,7 @@ class PatternTypeSpec(TypeSpec):
     def validate(self, errors, pos, val, errstr=''):
         if self.base.validate(errors, pos, val, errstr) == False:
             return False
-        for (type_, re, re_pos, invert_match) in self.res:
+        for (type_, re, re_pos, invert_match, patstr) in self.res:
             if type_ == 'libxml2':
                 is_valid = re.regexpExec(val) == 1
             elif type_ == 'lxml':


### PR DESCRIPTION
This change allows plugins to use the typespec to get pattern restrictions. 
Without this change, plugins have to find the original `type` statement and then look for `pattern` substatements. Obviously that's error-prone if statements like `refine` are in play.