### PR TITLE
Check revision to make sure it is a date.

### DIFF
--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -6,6 +6,7 @@ import sys
 import zlib
 import re
 import io
+from datetime import datetime
 
 from . import error
 from . import yang_parser
@@ -102,6 +103,14 @@ class Context(object):
                 else:
                     error.err_add(self.errors, module.pos, 'WBAD_REVISION',
                                   (latest_rev, ref, expect_revision))
+
+        lrev = latest_rev.split('-')
+        try:
+            dt = datetime(int(lrev[0]), int(lrev[1]), int(lrev[2]))
+        except Exception as e:
+            error.err_add(self.errors, module.pos, 'BAD_REVISION_DATE',
+                          (latest_rev, ref, str(e)))
+            return None
 
         if module.arg not in self.revs:
             self.revs[module.arg] = []

--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -104,13 +104,14 @@ class Context(object):
                     error.err_add(self.errors, module.pos, 'WBAD_REVISION',
                                   (latest_rev, ref, expect_revision))
 
-        lrev = latest_rev.split('-')
-        try:
-            dt = datetime(int(lrev[0]), int(lrev[1]), int(lrev[2]))
-        except Exception as e:
-            error.err_add(self.errors, module.pos, 'BAD_REVISION_DATE',
-                          (latest_rev, ref, str(e)))
-            return None
+        if latest_rev != 'unknown':
+            lrev = latest_rev.split('-')
+            try:
+                dt = datetime(int(lrev[0]), int(lrev[1]), int(lrev[2]))
+            except Exception as e:
+                error.err_add(self.errors, module.pos, 'BAD_REVISION_DATE',
+                              (latest_rev, ref, str(e)))
+                return None
 
         if module.arg not in self.revs:
             self.revs[module.arg] = []

--- a/pyang/error.py
+++ b/pyang/error.py
@@ -137,6 +137,9 @@ error_codes = \
     'FILENAME_BAD_REVISION':
       (4,
        'filename "%s" suggests invalid revision "%s", should match "%s"'),
+    'BAD_REVISION_DATE':
+      (2,
+       'revision "%s" in %s is not a valid date, %s'),
     'BAD_SUB_BELONGS_TO':
       (1,
        'module %s includes %s, but %s does not specify a correct belongs-to'),

--- a/test/test_bad/test_date/Makefile
+++ b/test/test_bad/test_date/Makefile
@@ -1,0 +1,2 @@
+test:
+	pyang test.yang --print-error-code 2>&1 | grep BAD_REVISION_DATE

--- a/test/test_bad/test_date/test.yang
+++ b/test/test_bad/test_date/test.yang
@@ -1,0 +1,11 @@
+module test {
+
+  namespace "http://example.com/test";
+
+  prefix "t";
+
+  revision 2018-02-29 {
+      description
+        "This is a out-of-bounds date.";
+  }
+}


### PR DESCRIPTION
This adds a check for the latest revision to ensure it is a valid date.
There was a case where a revision of 2018-02-29 was used, but February
2018 did not have 29 days.  This is known to break tooling.  It would be
better if this was caught early.

This error is being made major and it cannot be a warning.