### PR TITLE
Make sure to close open files

### DIFF
--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -483,6 +483,8 @@ class FileRepository(Repository):
         except UnicodeDecodeError as ex:
             s = str(ex).replace('utf-8', 'utf8')
             raise self.ReadError(absfilename + ": unicode error: " + s)
+        finally:
+            fd.close()
 
         if format is None:
             format = util.guess_format(text)


### PR DESCRIPTION
Fix the following warning:

```
.../python3.5/site-packages/pyang/__init__.py:170: ResourceWarning: unclosed file <_io.TextIOWrapper name='xxx.yang' mode='r' encoding='utf-8'>
```