### PR TITLE
remove logic to over-check submodule dependency for leaf-ref. 

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2692,8 +2692,11 @@ def validate_leafref_path(ctx, stmt, path_spec, path,
             if ptr.keyword in _keyword_with_children:
                 ptr = search_data_node(ptr.i_children, module_name, name,
                                        last_skipped)
-                if not is_submodule_included(path, ptr):
-                    ptr = None
+
+                ## comment out following 2 lines to fix issue #396
+                ##if not is_submodule_included(path, ptr):
+                ##    ptr = None
+
                 if ptr is None:
                     err_add(ctx.errors, pathpos, 'LEAFREF_IDENTIFIER_NOT_FOUND',
                             (module_name, name, stmt.arg, stmt.pos))


### PR DESCRIPTION
for the detail bug, refer to issue#396.
Here is the use case description:
submodule A uses grouping defined in submodule B, so A includes B.  But some leaf-ref in B refer to other leaf object defined in A. but A cannot include B, otherwise "circulate include" error will be reported.  So leaf-ref xpath validation shouldn't assume B includes A.

Change-Id: I979851ec224734d4a59f090587c0dd5d0e391b21