### PR TITLE
Fix issue#399: keep yang line number in yin file

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2692,8 +2692,11 @@ def validate_leafref_path(ctx, stmt, path_spec, path,
             if ptr.keyword in _keyword_with_children:
                 ptr = search_data_node(ptr.i_children, module_name, name,
                                        last_skipped)
-                if not is_submodule_included(path, ptr):
-                    ptr = None
+
+                ## comment out following 2 lines to fix issue #396
+                ##if not is_submodule_included(path, ptr):
+                ##    ptr = None
+
                 if ptr is None:
                     err_add(ctx.errors, pathpos, 'LEAFREF_IDENTIFIER_NOT_FOUND',
                             (module_name, name, stmt.arg, stmt.pos))

--- a/pyang/translators/yin.py
+++ b/pyang/translators/yin.py
@@ -28,6 +28,10 @@ class YINPlugin(plugin.PyangPlugin):
                                  dest="yin_pretty_strings",
                                  action="store_true",
                                  help="Pretty print strings"),
+            optparse.make_option("--yin-keep-line-number",
+                                 dest="yin_keep_line_number",
+                                 action="store_true",
+                                 help="Keep YANG file line number in yin file"),
             ]
         g = optparser.add_option_group("YIN output specific options")
         g.add_options(optlist)
@@ -117,14 +121,17 @@ def emit_stmt(ctx, module, stmt, fd, indent, indentstep):
         (argname, argiselem) = syntax.yin_map[stmt.raw_keyword]
         tag = stmt.raw_keyword
     if argiselem == False or argname is None:
+        posatt = '' # fix issue#399 to add line number
+        if ctx.opts.yin_keep_line_number is not None:
+            posatt = ' line=' + quoteattr(str(stmt.pos.line))
         if argname is None:
             attr = ''
         else:
             attr = ' ' + argname + '=' + quoteattr(stmt.arg)
         if len(stmt.substmts) == 0:
-            fd.write(indent + '<' + tag + attr + '/>\n')
+            fd.write(indent + '<' + tag + attr + posatt + '/>\n')
         else:
-            fd.write(indent + '<' + tag + attr + '>\n')
+            fd.write(indent + '<' + tag + attr + posatt + '>\n')
             for s in stmt.substmts:
                 emit_stmt(ctx, module, s, fd, indent + indentstep,
                           indentstep)

--- a/pyang/yin_parser.py
+++ b/pyang/yin_parser.py
@@ -223,7 +223,8 @@ class YinParser(object):
         for at in attrs:
             (ns, local_name) = self.split_qname(at)
             if ns is None:
-                error.err_add(self.ctx.errors, pos,
+                if local_name != 'line': # fix issue#399
+                    error.err_add(self.ctx.errors, pos,
                               'UNEXPECTED_ATTRIBUTE', local_name)
             elif ns == yin_namespace:
                 error.err_add(self.ctx.errors, pos,


### PR DESCRIPTION
usage: pyang -f yin --yin-keep-line-number <yang file>
the generated yin xml file will contains yang line number, so the GUI tool, which load yin file, could easy map the tree node to yang line number for debug.