### PR TITLE
Fix json config validation error message

### DIFF
--- a/bin/json2xml
+++ b/bin/json2xml
@@ -184,7 +184,7 @@ class Translator (object):
                         knode = el.find(self.et_qname(*k))
                         try:
                             el.remove(knode)
-                        except TypeError:
+                        except (ValueError, TypeError):
                             raise MissingKeyError(ent_path, k)
                         el.insert(0,knode)
                     i += 1


### PR DESCRIPTION
Fixes #402

If the key is missing in that case the execption raised
by lxml on calling remove() method is `TypeError`.
To fix this issue to display proper error message catch
`TypeError` exception.