### PR TITLE
preventing flymake temp files to be used as plugins

### DIFF
--- a/pyang/plugin.py
+++ b/pyang/plugin.py
@@ -39,7 +39,7 @@ def init(plugindirs=[]):
             continue
         for fname in fnames:
             if not fname.startswith(".#") and fname.endswith(".py") and \
-               fname != '__init__.py':
+               fname != '__init__.py' and not fname.endswith("_flymake.py"):
                 pluginmod = __import__(fname[:-3])
                 try:
                     pluginmod.pyang_plugin_init()


### PR DESCRIPTION
Emacs' flymake creates temporary files alongside the edited ones; flymake is started automatically when the buffer is saved, and if you start pyang at the same time, the temporary file would be used as another plugin (if the edited file happens to be a plugin).