### PR TITLE
Feature/avoid crash on invalid xpath

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2789,7 +2789,7 @@ def check_and_return_parameters(expected_count, tokens, func_name):
     if tokens[x][1] == '(':
         x += 1
 
-    while brackets:
+    while brackets and x < len(tokens):
         if tokens[x][1] == ')':
             parameter.append(tokens[x][1])
             brackets -= 1

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2623,7 +2623,7 @@ def check_path(path, stmt, ctx):
         path = path[:-1]
     parts = path.split('/')
     if parts[0] == '':
-        if ':' in parts[1]:
+        if len(parts) > 1 and ':' in parts[1]:
             prefix = parts[1].split(':')[0]
             data_holding_stmts = prefix_to_module(stmt.i_module,
                                                   prefix, stmt.pos, ctx.errors)


### PR DESCRIPTION
These changes avoid the crashes reported in issue #438. They are simple-minded changes that don't attempt any recovery or error reporting.