### PR TITLE
fixing pyang.bat on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ script_files = []
 if os.name == "nt":
     pyang_bat_file = "{}/{}.bat".format(tempfile.gettempdir(), "pyang")
     with open(pyang_bat_file, 'w') as script:
-        script.write('@echo off\npython %cd%\pyang %*\n')
+        script.write('@echo off\npython %~dp0pyang %*\n')
     script_files = ['bin/pyang', 'bin/yang2html', 'bin/yang2dsdl', 'bin/json2xml', pyang_bat_file]
 else:
     script_files = ['bin/pyang', 'bin/yang2html', 'bin/yang2dsdl', 'bin/json2xml']


### PR DESCRIPTION
The "%cd%" in the pyang.bat script returned the current working directory - hence the path "%cd%\pyang" pointed mostly to an non existing file. The new "%~dp0" returns the current directory location of the pyang.bat itself - that should the the same directory where the "pyang" file is installed.