### PR TITLE
Added template to gen-relaxng.xsl to skip elements outside rng namespace

### DIFF
--- a/test/test_dsdl/ll-extension.yin
+++ b/test/test_dsdl/ll-extension.yin
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="ll-extension"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:test="http://example.com/ll/extension">
+  <namespace uri="http://example.com/ll/extension"/>
+  <prefix value="ext"/>
+  <extension name="metadata">
+    <description>
+      <text>Some arbitrary model metadata</text>
+    </description>
+    <argument name="data">
+      <yin-element value="true"/>
+    </argument>
+  </extension>
+</module>

--- a/test/test_dsdl/ll-obu.yin
+++ b/test/test_dsdl/ll-obu.yin
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module name="ll-obu"
         xmlns="urn:ietf:params:xml:ns:yang:yin:1"
-        xmlns:test="http://example.com/ll/obu">
+        xmlns:test="http://example.com/ll/obu"
+        xmlns:ext="http://example.com/ll/extension">
   <namespace uri="http://example.com/ll/obu"/>
   <prefix value="obu"/>
+  <import module="ll-extension">
+    <prefix value="ext"/>
+  </import>
   <container name="users">
     <list name="user">
       <key value="uid"/>
@@ -18,6 +22,9 @@
     </list>
   </container>
   <container name="admins">
+    <ext:metadata>
+        <ext:data>fake metadata</ext:data>
+    </ext:metadata>
     <leaf-list name="admin">
       <ordered-by value="user"/>
       <type name="string"/>

--- a/xslt/gen-relaxng.xsl
+++ b/xslt/gen-relaxng.xsl
@@ -373,6 +373,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template match="*">
+    <!-- Do nothing for elements in namespaces other than rng, to prevent the
+    outputting of text nodes defined by extensions -->
+  </xsl:template>
+
   <xsl:template match="rng:oneOrMore" mode="process">
     <xsl:choose>
       <xsl:when test="$target='edit-config'">


### PR DESCRIPTION
This prevents extension text from appearing in generated RNG files

Fixes #455