### PR TITLE
Create Statement subclasses to waste less memory on unused __slots__.

### DIFF
--- a/pyang/yang_parser.py
+++ b/pyang/yang_parser.py
@@ -314,7 +314,11 @@ class YangParser(object):
         if keywd == 'yang-version' and arg == '1.1':
             self.tokenizer.is_1_1 = True;
             self.tokenizer.strict_quoting = True
-        stmt = statements.Statement(self.top, parent, self.pos, keywd, arg)
+
+        stmt_class = statements.STMT_CLASS_FOR_KEYWD.get(keywd,
+                                                         statements.Statement)
+        stmt = stmt_class(self.top, parent, self.pos, keywd, arg)
+
         if self.ctx.keep_arg_substrings and argstrs is not None:
             stmt.arg_substrings = argstrs
         if self.top is None:


### PR DESCRIPTION
Since most of the memory overhead of pyang is in Statement objects, and a surprising amount of the run time of pyang is spent in copying Statement objects (copying out from groupings, for example), anything we can do to reduce the size of a typical Statement and the number of distinct attributes it has can give us a lot of benefit performance-wise.

Some of the Statement attributes are generic and apply to a broad swath of YANG statements, but many are specific to one particular keyword or a small number of related keywords. Hence, by creating Statement subclasses for particular keywords and moving the attributes to those subclasses, we reduce the size of the average Statement by a significant amount. In my testing with a variety of YANG modules (including the quite large Cisco-IOS-XE-native model plus all of its various augmenters), this change reduces memory overhead by about 20% and reduces execution time by about 10%.