### PR TITLE
Fix for Issue #468

### DIFF
--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -651,9 +651,6 @@ def chk_range(old, new, oldts, newts, ctx):
         if tmperrors != []:
             err_add(ctx.errors, new.pos, 'CHK_RESTRICTION_CHANGED',
                     'range')
-    elif type(nts) == types.RangeTypeSpec:
-        err_add(ctx.errors, nts.ranges_pos, 'CHK_DEF_ADDED',
-                ('range', str(nts.ranges)))
 
 def chk_decimal64(old, new, oldts, newts, ctx):
     oldbasets = get_base_type(oldts)

--- a/test/test_update/Makefile
+++ b/test/test_update/Makefile
@@ -1,6 +1,6 @@
 PYANG = pyang --print-error-code --check-update-from
 
-MODULES = a c f h
+MODULES = a c f h i
 DEVIATION_MODULES = d e
 
 test:

--- a/test/test_update/expect/i.out
+++ b/test/test_update/expect/i.out
@@ -1,0 +1,5 @@
+i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i@2014-04-01.yang:1: error: CHK_DEF_REMOVED

--- a/test/test_update/expect/i.out
+++ b/test/test_update/expect/i.out
@@ -4,7 +4,7 @@ i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
-i@2014-04-01.yang:15: error: CHK_INVALID_STATUS
+i@2014-04-01.yang:24: error: CHK_INVALID_STATUS
 i-sub.yang:14: error: CHK_INVALID_STATUS
 i-sub.yang:19: error: CHK_DEF_REMOVED
 i-sub.yang:24: error: CHK_RESTRICTION_CHANGED

--- a/test/test_update/expect/i.out
+++ b/test/test_update/expect/i.out
@@ -3,5 +3,8 @@ i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i@2014-04-01.yang:15: error: CHK_INVALID_STATUS
 i-sub.yang:14: error: CHK_INVALID_STATUS
 i-sub.yang:19: error: CHK_DEF_REMOVED
+i-sub.yang:24: error: CHK_RESTRICTION_CHANGED

--- a/test/test_update/expect/i.out
+++ b/test/test_update/expect/i.out
@@ -3,3 +3,5 @@ i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
 i@2014-04-01.yang:1: error: CHK_DEF_REMOVED
+i-sub.yang:14: error: CHK_INVALID_STATUS
+i-sub.yang:19: error: CHK_DEF_REMOVED

--- a/test/test_update/i-sub.yang
+++ b/test/test_update/i-sub.yang
@@ -22,7 +22,7 @@ submodule i-sub {
      }
      leaf g2-b {
         type uint16 {
-           range "1..500";
+           range "1..400";
         }
      }
   }

--- a/test/test_update/i-sub.yang
+++ b/test/test_update/i-sub.yang
@@ -1,0 +1,30 @@
+submodule i-sub {
+  belongs-to i {
+     prefix i;
+  }
+
+  revision 2014-04-01;
+
+  feature my_feature_2;
+
+  extension my_extension_2;
+
+  identity my_identity_2;
+
+  typedef my-type2 {
+    type uint32;
+  }
+  
+  grouping my-grouping-2 {
+     leaf g2-a {
+        mandatory true;
+        type string;
+     }
+     leaf g2-b {
+        type uint16 {
+           range "1..500";
+        }
+     }
+  }
+}
+

--- a/test/test_update/i.yang
+++ b/test/test_update/i.yang
@@ -17,6 +17,7 @@ module i {
   identity my_identity_3;
 
   typedef my-type1 {
+    status obsolete;
     type string;
   }
 

--- a/test/test_update/i.yang
+++ b/test/test_update/i.yang
@@ -1,0 +1,66 @@
+module i {
+  namespace urn:i;
+  prefix i;
+
+  revision 2014-03-01;
+
+  feature my_feature_1;
+  feature my_feature_2;
+  feature my_feature_3;
+
+  extension my_extension_1;
+  extension my_extension_2;
+  extension my_extension_3;
+
+  identity my_identity_1;
+  identity my_identity_2;
+  identity my_identity_3;
+
+  typedef my-type1 {
+    type string;
+  }
+
+  typedef my-type2 {
+    status deprecated;
+    type uint32;
+  }
+  
+  typedef my-type3 {
+    type uint16;
+  }
+  
+  grouping my-grouping-1 {
+     leaf g1-a {
+        type string;
+     }
+     leaf g1-b {
+        type string;
+     }
+  }
+  
+  grouping my-grouping-2 {
+     leaf g2-a {
+        mandatory true;
+        if-feature my_feature_2;
+        type string;
+     }
+     leaf g2-b {
+        type uint16 {
+           range "1..500";
+        }
+     }
+  }
+
+  grouping my-grouping-3 {
+     leaf g3-a {
+        type string;
+     }
+     leaf g3-b {
+        type uint32;
+     }
+  }
+
+  container x {
+  }
+}
+

--- a/test/test_update/i.yang
+++ b/test/test_update/i.yang
@@ -17,25 +17,33 @@ module i {
   identity my_identity_3;
 
   typedef my-type1 {
-    status obsolete;
-    type string;
+    type enumeration {
+       enum a;
+       enum b;
+    }
   }
 
   typedef my-type2 {
     status deprecated;
     type uint32;
   }
-  
+
   typedef my-type3 {
-    type uint16;
+    type bits {
+       bit a { position 1; }
+       bit b { position 3; }
+    }
   }
-  
+
   grouping my-grouping-1 {
      leaf g1-a {
+        status obsolete;
         type string;
      }
      leaf g1-b {
-        type string;
+        type decimal64 {
+           fraction-digits 4;
+        }
      }
   }
   

--- a/test/test_update/i@2014-04-01.yang
+++ b/test/test_update/i@2014-04-01.yang
@@ -13,15 +13,21 @@ module i {
   identity my_identity_1;
 
   typedef my-type1 {
-    type string;
+    type enumeration {
+       enum a;
+       enum b;
+    }
   }
 
   grouping my-grouping-1 {
      leaf g1-a {
+        status current;
         type string;
      }
      leaf g1-b {
-        type string;
+        type decimal64 {
+           fraction-digits 4;
+        }
      }
   }
 }

--- a/test/test_update/i@2014-04-01.yang
+++ b/test/test_update/i@2014-04-01.yang
@@ -1,0 +1,31 @@
+module i {
+  namespace urn:i;
+  prefix i;
+
+  include i-sub;
+
+  revision 2014-04-01;
+
+  feature my_feature_1;
+
+  extension my_extension_1;
+
+  identity my_identity_1;
+
+  typedef my-type1 {
+    type string;
+  }
+
+  grouping my-grouping-1 {
+     leaf g1-a {
+        type string;
+     }
+     leaf g1-b {
+        type string;
+     }
+  }
+  
+  container x {
+  }
+}
+

--- a/test/test_update/i@2014-04-01.yang
+++ b/test/test_update/i@2014-04-01.yang
@@ -24,8 +24,5 @@ module i {
         type string;
      }
   }
-  
-  container x {
-  }
 }
 


### PR DESCRIPTION
Issue 468 (https://github.com/mbj4668/pyang/issues/468) describes a problem where groupings moved to a submodule are not found by check-update resulting in incorrect error message that the grouping is not found. Note that the issue also applies to the typedef, extension, feature and identity statements.

The root cause is that chk_stmt does not find these statements when they have been moved to a submodule. The solution I'm proposing is to look in the respective dictionaries for groupings, typedefs, extensions, features and identities - this is what the new funcion chk_stmt_definitions provides.

New test cases are added to test the following:

Moving grouping, feature, typedef, extension, identity to a submodule - verify no error
Deleting grouping, feature, typedef, extension, identity - verify that we do get errors
Test that status and if-feature errors are caught when they occur in the submodule