### PR TITLE
Fix for AttributeError: 'NoneType' object has no attribute pos in

### DIFF
--- a/pyang/plugins/depend.py
+++ b/pyang/plugins/depend.py
@@ -75,6 +75,8 @@ def emit_depend(ctx, modules, fd):
                 continue
             if ctx.opts.depend_include_path:
                 m = ctx.get_module(i)
+                if m is None:
+                    continue
                 if ctx.opts.depend_extension is None:
                     filename = m.pos.ref
                 else:


### PR DESCRIPTION
line 81 function emit_depend will throw attributenotfound error when m is None
and we reference m.pos.ref