### PR TITLE
Ensure the ietf-netconf namespace isn't added multiple times

### DIFF
--- a/bin/json2xml
+++ b/bin/json2xml
@@ -105,8 +105,13 @@ class Translator (object):
         self.uri = {}
         self.node_modules = set()
         for m in jtox["modules"]:
-            self.prefix[m], self.uri[m] = jtox["modules"][m]
-            ET.register_namespace(self.prefix[m], self.uri[m])
+            # The namespace urn:ietf:params:xml:ns:netconf:base:1.0 is added by the default. 
+            # Don't add it twice as this will cause the generated XML to be invalid
+            prefix, uri = jtox["modules"][m]
+            if uri != "urn:ietf:params:xml:ns:netconf:base:1.0":
+                self.prefix[m] = prefix
+                self.uri[m] = uri
+                ET.register_namespace(self.prefix[m], self.uri[m])
         ident = "[a-zA-Z_][-_.a-zA-Z0-9]*"
         self.qn_re = re.compile(r"^\s*(%s(?::%s)?)\s*(.*)$" % ((ident,)*2))
         self.num_re = re.compile(r"^\s*([0-9]+)\s*\]\s*(.*)$")

--- a/test/test_json/amod.yang
+++ b/test/test_json/amod.yang
@@ -2,6 +2,10 @@ module amod {
   namespace "http://example.com/a";
   prefix a;
 
+  import ietf-netconf {
+    prefix nc;
+  }
+
   include asub;
 
   feature abc;
@@ -39,6 +43,14 @@ module amod {
     leaf foo {
       type int64;
       default "-1";
+    }
+    leaf session-id {
+      type nc:session-id-or-zero-type;
+      mandatory false;
+      description
+        "Identifier of the session.
+         A NETCONF session MUST be identified by a non-zero value.
+         A non-NETCONF session MAY be identified by the value zero.";
     }
     leaf-list pac {
       type bool;


### PR DESCRIPTION
If any of the yang modules used imports the ietf-netconf module yang2xml will register that namespace multiple times. This causes the generated XML to be invalid.

This PR ensures that the ietf-netconf namespace is only registered once.