### PR TITLE
Fix TypeError when parsing XPath union

### DIFF
--- a/pyang/xpath_parser.py
+++ b/pyang/xpath_parser.py
@@ -320,17 +320,17 @@ def _mk_union(a, b):
     if a[0] == 'union' and b[0] == 'union':
         v = list(a[1])
         v.extend(b[1])
-        ('union', v)
+        return ('union', v)
     elif a[0] == 'union':
         v = list(a[1])
         v.append(b[1])
-        ('union', v)
+        return ('union', v)
     elif b[0] == 'union':
         v = [b]
         v.extend(a[1])
-        ('union', v)
+        return ('union', v)
     else:
-        ('union', [a, b])
+        return ('union', [a, b])
 
 def _expand_double_slash():
     return ('step', 'descendant-or-self', ('node_type', 'node'), [])


### PR DESCRIPTION
This PR adds some missing return statements in _mk_union, the lack of which resulted in a
TypeError exception being raised when parsing an XPath union with 3 or more terms. 

For example, attempting to validate this module:

```yang
module simple {
  namespace "urn:example.com:simple";
  prefix smpl;

  description "Reproduce pyang 2.0.1 parse failure";

  revision 2019-07-11 {
    description "First version.";
  }

  container colours {

    must "count(blue|yellow|green) = 1" {
      error-message "Must specify just one of 'blue', 'yellow' or 'green'";
    }

    leaf green {
      type uint16;
    }

    leaf blue {
      type empty;
    }

    leaf yellow {
      type uint16;
    }
  }
}
```
results in this traceback:
```
$ pyang simple.yang
Traceback (most recent call last):
  File "/home/sbayley/.local/share/virtualenvs/pyang-lqqFW4m_/bin/pyang", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/sbayley/pyang/bin/pyang", line 493, in <module>
    run()
  File "/home/sbayley/pyang/bin/pyang", line 372, in run
    ctx.validate()
  File "/home/sbayley/pyang/pyang/__init__.py", line 338, in validate
    statements.validate_module(self, m)
  File "/home/sbayley/pyang/pyang/statements.py", line 409, in validate_module
    iterate(module, phase)
  File "/home/sbayley/pyang/pyang/statements.py", line 404, in iterate
    iterate(s, phase)
  File "/home/sbayley/pyang/pyang/statements.py", line 404, in iterate
    iterate(s, phase)
  File "/home/sbayley/pyang/pyang/statements.py", line 366, in iterate
    res = f(ctx, stmt)
  File "/home/sbayley/pyang/pyang/statements.py", line 202, in <lambda>
    ('type', 'must'):lambda ctx, s: v_type_must(ctx, s),
  File "/home/sbayley/pyang/pyang/statements.py", line 1351, in v_type_must
    xpath.v_xpath(ctx, stmt, None)
  File "/home/sbayley/pyang/pyang/xpath.py", line 81, in v_xpath
    q = xpath_parser.parse(stmt.arg)
  File "/home/sbayley/pyang/pyang/xpath_parser.py", line 13, in parse
    return parser.parse(s, lexer = lexer, debug = False)
  File "/home/sbayley/pyang/pyang/yacc.py", line 336, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
  File "/home/sbayley/pyang/pyang/yacc.py", line 1123, in parseopt_notrack
    p.callable(pslice)
  File "/home/sbayley/pyang/pyang/xpath_parser.py", line 192, in p_union_expr_2
    p[0] = _mk_union(p[1], p[3])
  File "/home/sbayley/pyang/pyang/xpath_parser.py", line 320, in _mk_union
    if a[0] == 'union' and b[0] == 'union':
TypeError: 'NoneType' object is not subscriptable

```