### PR TITLE
uml: s/groupings/augmentations in aug opt help

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -68,7 +68,7 @@ class UMLPlugin(plugin.PyangPlugin):
                                  action="store_true",
                                  dest="uml_inline_augments",
                                  default =False,
-                                 help="Inline groupings where they are used."),
+                                 help="Inline augmentations where they are used."),
             optparse.make_option("--uml-description",
                                  action="store_true",
                                  dest="uml_descr",


### PR DESCRIPTION
I believe the help for --uml-inline-augments should read "augmentations"
instead of "groupings", looks like a copy-paste error from the previous
option.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>