### PR TITLE
Add pyang --schema-from-path option

### DIFF
--- a/bin/pyang
+++ b/bin/pyang
@@ -132,6 +132,11 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                              action="append",
                              help=os.pathsep + "-separated search path for yin"
                              " and yang modules"),
+        optparse.make_option("--schema-from-path",
+                             dest="schema_from_path",
+                             default=False,
+                             action="store_true",
+                             help="Automatically load all YANG in path."),
         optparse.make_option("--plugindir",
                              dest="plugindir",
                              help="Load pyang plugins from PLUGINDIR"),
@@ -299,6 +304,14 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                     "module '%s' specified in hello not found.\n" % emarg)
                 sys.exit(1)
             modules.append(mod)
+    elif o.schema_from_path:
+        for module_name in ctx.revs.keys():
+            module = ctx.search_module(0, module_name)
+            if module is None:
+                sys.stderr.write(
+                    "module '%s' failed to load in schema parsing.\n" % module_name)
+                sys.exit(1)
+            modules.append(module)
     else:
         if len(filenames) == 0:
             text = sys.stdin.read()


### PR DESCRIPTION
Option indicates that `pyang` should attempt to load all YANG within the current path instead of desiring a NETCONF hello or explicit filenames.

```bash
[pyang] pyang -f tree -p ../oc/release/models --schema-from-path 2>/dev/null | grep module | head -n 10
module: openconfig-access-points
module: openconfig-wifi-phy
module: openconfig-wifi-mac
module: openconfig-ap-manager
module: openconfig-probes
module: openconfig-bfd
module: openconfig-network-instance
module: openconfig-lldp
module: openconfig-qos
module: openconfig-module-catalog
```

Not certain on correctness of method of loading.