### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/pyang/error.py
+++ b/pyang/error.py
@@ -293,10 +293,10 @@ error_codes = \
        ' other nodes in the unique expression'),
     'ILLEGAL_ESCAPE':
       (1,
-       'the escape sequence "\%s" is illegal in double quoted strings'),
+       'the escape sequence "\\%s" is illegal in double quoted strings'),
     'ILLEGAL_ESCAPE_WARN':
       (4,
-       'the escape sequence "\%s" is unsafe in double quoted strings' \
+       'the escape sequence "\\%s" is unsafe in double quoted strings' \
        ' - pass the flag --lax-quote-checks to avoid this warning'),
     'UNIQUE_IS_KEY':
       (4,

--- a/pyang/plugins/ietf.py
+++ b/pyang/plugins/ietf.py
@@ -114,7 +114,7 @@ must contain the following text:
 """)
 
 rfc8174_str = \
-"""The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+r"""The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
 NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
 'MAY', and 'OPTIONAL' in this document are to be interpreted as
 described in BCP 14 \(RFC 2119\) \(RFC 8174\) when, and only when,

--- a/pyang/plugins/smi.py
+++ b/pyang/plugins/smi.py
@@ -23,8 +23,8 @@ from pyang.error import err_add
 
 smi_module_name = 'ietf-yang-smiv2'
 
-re_smi_oid = re.compile("^(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))"
-                          + "(\.(0|([1-9]\d*)))*$")
+re_smi_oid = re.compile(r"^(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))" \
+                        r"(\.(0|([1-9]\d*)))*$")
 
 class SMIPlugin(plugin.PyangPlugin):
     pass

--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -406,7 +406,7 @@ def print_node(s, module, fd, prefix, path, mode, depth, llen,
 
     if s.keyword == 'list':
         if s.search_one('key') is not None:
-            keystr = " [%s]" % re.sub('\s+', ' ', s.search_one('key').arg)
+            keystr = " [%s]" % re.sub(r'\s+', ' ', s.search_one('key').arg)
             if (llen is not None and
                 len(line) + len(keystr) > llen):
                 fd.write(line + '\n')

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -114,7 +114,7 @@ class Abort(Exception):
 ### Constants
 
 re_path = re.compile('(.*)/(.*)')
-re_deref = re.compile('deref\s*\(\s*(.*)\s*\)/\.\./(.*)')
+re_deref = re.compile(r'deref\s*\(\s*(.*)\s*\)/\.\./(.*)')
 re_and_or = re.compile(r'\band\b|\bor\b')
 
 data_definition_keywords = ['container', 'leaf', 'leaf-list', 'list',

--- a/pyang/syntax.py
+++ b/pyang/syntax.py
@@ -11,7 +11,7 @@ import datetime
 identifier = r"[_A-Za-z][._\-A-Za-z0-9]*"
 prefix = identifier
 keyword = '((' + prefix + '):)?(' + identifier + ')'
-comment = '(/\*([^*]|[\r\n\s]|(\*+([^*/]|[\r\n\s])))*\*+/)|(//.*)|(/\*.*)'
+comment = r'(/\*([^*]|[\r\n\s]|(\*+([^*/]|[\r\n\s])))*\*+/)|(//.*)|(/\*.*)'
 
 # no group version of keyword
 keyword_ng = '(?:(' + prefix + '):)?(?:' + identifier + ')'
@@ -24,15 +24,15 @@ pos_integer = r"[1-9][0-9]*"
 nonneg_integer = r"(0|([1-9][0-9]*))"
 integer_ = r"[+-]?" + nonneg_integer
 decimal_ = integer_ + r"(\.[0-9]+)?"
-length_str = '((min|max|[0-9]+)\s*' \
-             '(\.\.\s*' \
-             '(min|max|[0-9]+)\s*)?)'
-length_expr = length_str + '(\|\s*' + length_str + ')*'
+length_str = r'((min|max|[0-9]+)\s*' \
+             r'(\.\.\s*' \
+             r'(min|max|[0-9]+)\s*)?)'
+length_expr = length_str + r'(\|\s*' + length_str + r')*'
 re_length_part = re.compile(length_str)
-range_str = '((\-INF|min|max|((\+|\-)?[0-9]+(\.[0-9]+)?))\s*' \
-            '(\.\.\s*' \
-            '(INF|min|max|(\+|\-)?[0-9]+(\.[0-9]+)?)\s*)?)'
-range_expr = range_str + '(\|\s*' + range_str + ')*'
+range_str = r'((\-INF|min|max|((\+|\-)?[0-9]+(\.[0-9]+)?))\s*' \
+            r'(\.\.\s*' \
+            r'(INF|min|max|(\+|\-)?[0-9]+(\.[0-9]+)?)\s*)?)'
+range_expr = range_str + r'(\|\s*' + range_str + r')*'
 re_range_part = re.compile(range_str)
 
 re_identifier = re.compile("^" + identifier + "$")
@@ -49,14 +49,15 @@ descendant_path_arg = node_id + "(" + path_predicate + ")*" + \
                       "(?:" + absolute_path_arg + ")?"
 relative_path_arg = r"(\.\./)*" + descendant_path_arg
 deref_path_arg = r"deref\s*\(\s*(?:" + relative_path_arg + \
-                 ")\s*\)/\.\./" + relative_path_arg
+                 r")\s*\)/\.\./" + relative_path_arg
 path_arg = "(" + absolute_path_arg + "|" + relative_path_arg + "|" + \
            deref_path_arg + ")"
 absolute_schema_nodeid = "(/" + node_id + ")+"
 descendant_schema_nodeid = node_id + "(" + absolute_schema_nodeid + ")?"
 schema_nodeid = "("+absolute_schema_nodeid+"|"+descendant_schema_nodeid+")"
-unique_arg = descendant_schema_nodeid + "(\s+" + descendant_schema_nodeid + ")*"
-key_arg = node_id + "(\s+" + node_id + ")*"
+unique_arg = descendant_schema_nodeid + \
+             r"(\s+" + descendant_schema_nodeid + r")*"
+key_arg = node_id + r"(\s+" + node_id + r")*"
 re_schema_node_id_part = re.compile('/' + keyword)
 
 # URI - RFC 3986, Appendix A
@@ -108,10 +109,10 @@ re_nonneg_integer = re.compile("^" + nonneg_integer + "$")
 re_integer = re.compile("^" + integer_ + "$")
 re_decimal = re.compile("^" + decimal_ + "$")
 re_uri = re.compile("^" + uri + "$")
-re_boolean = re.compile("^(true|false)$")
-re_version = re.compile("^(1|(1\.1))$")
+re_boolean = re.compile(r"^(true|false)$")
+re_version = re.compile(r"^(1|(1\.1))$")
 re_date = re.compile("^" + date +"$")
-re_status = re.compile("^(current|obsolete|deprecated)$")
+re_status = re.compile(r"^(current|obsolete|deprecated)$")
 re_key = re.compile("^" + key_arg + "$")
 re_length = re.compile("^" + length_expr + "$")
 re_range = re.compile("^" + range_expr + "$")
@@ -125,7 +126,7 @@ re_unique = re.compile("^" + unique_arg + "$")
 re_schema_nodeid = re.compile("^" + schema_nodeid + "$")
 re_absolute_schema_nodeid = re.compile("^" + absolute_schema_nodeid + "$")
 re_descendant_schema_nodeid = re.compile("^" + descendant_schema_nodeid + "$")
-re_deviate = re.compile("^(add|delete|replace|not-supported)$")
+re_deviate = re.compile(r"^(add|delete|replace|not-supported)$")
 
 # Not part of YANG syntax per se but useful for pyang in several places
 re_filename = re.compile(r"^([^@]*?)" +          # putative module name


### PR DESCRIPTION
Hi,

When running under Python3, we get a number of `DeprecationWarning: invalid escape sequence` warnings. This pull-request fixes these. I tried following the convention of using the raw-string `r""` prefix for regexp strings, or extra backslashes for other strings.

To avoid more of these creeping in, running `pycodestyle --select=W6 .` from the top of the code repository will flag this error.