### PR TITLE
Set the parent on a  non-copied substatement

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2881,6 +2881,7 @@ class Statement(object):
                 pass
             elif s.keyword in nocopy:
                 new.substmts.append(s)
+                s.parent = new
             else:
                 new.substmts.append(s.copy(new, uses, False,
                                            nocopy, ignore, copyf))


### PR DESCRIPTION
Fixes #527 
See that issue for more details. Is there a good place I can add a test for this case? It seems like `test/test_good/deref.yang` has some relevant content, but I don't really understand how that is being used in the test itself.