### PR TITLE
Align the --bbf option with the options that BBF uses for validating its modules

### DIFF
--- a/pyang/plugins/bbf.py
+++ b/pyang/plugins/bbf.py
@@ -19,6 +19,7 @@ class BBFPlugin(lint.LintPlugin):
         lint.LintPlugin.__init__(self)
         self.namespace_prefixes = ['urn:bbf:yang:']
         self.modulename_prefixes = ['bbf']
+        self.ensure_hyphenated_names = True
 
     def add_opts(self, optparser):
         optlist = [
@@ -34,3 +35,5 @@ class BBFPlugin(lint.LintPlugin):
         if not ctx.opts.bbf:
             return
         self._setup_ctx(ctx)
+        if ctx.max_line_len is None:
+            ctx.max_line_len = 70

--- a/pyang/plugins/lint.py
+++ b/pyang/plugins/lint.py
@@ -37,6 +37,10 @@ class LintPlugin(plugin.PyangPlugin):
         # define its own checks.
         self.modulename_prefixes = []
 
+        # Set this to control whether to check that names are hyphenated
+        # and don't contain any upper-case characters
+        self.ensure_hyphenated_names = None
+
     def add_opts(self, optparser):
         optlist = [
             optparse.make_option("--lint",
@@ -80,6 +84,11 @@ class LintPlugin(plugin.PyangPlugin):
         self.namespace_prefixes.extend(ctx.opts.lint_namespace_prefixes)
         self.modulename_prefixes.extend(ctx.opts.lint_modulename_prefixes)
 
+        # copy other lint options to instance variables, taking care not to
+        # overwrite any settings from derived class constructors
+        if ctx.opts.lint_ensure_hyphenated_names:
+            self.ensure_hyphenated_names = True
+
         # register our grammar validation funs
 
         statements.add_validation_var(
@@ -103,7 +112,7 @@ class LintPlugin(plugin.PyangPlugin):
             'grammar', ['$chk_recommended'],
             lambda ctx, s: v_chk_recommended_substmt(ctx, s))
 
-        if ctx.opts.lint_ensure_hyphenated_names:
+        if self.ensure_hyphenated_names:
             statements.add_validation_fun(
                 'grammar', ['*'],
                 lambda ctx, s: v_chk_hyphenated_names(ctx, s))


### PR DESCRIPTION
I haven't added any tests. Do you need any?

(Note that this PR also modifies the lint plugin. I don't think this will affect any other plugins, because none of them set 'ensure_hyphenated_names'.)