### PR TITLE
Final of the large-scale changes: Code improvements for idiomatic python style

### DIFF
--- a/bin/json2xml
+++ b/bin/json2xml
@@ -27,14 +27,15 @@ class Error(Exception):
 class DataTypeError(Error):
     """Exception raised for values with wrong type."""
 
-    def __init__(self, path, type, value):
+    def __init__(self, path, datatype, value):
         Error.__init__(self, path)
-        self.type = type
+        self.datatype = datatype
         self.value = value
 
     def __str__(self):
-        return (Error.__str__(self) +
-                ' - %s is not a valid value of "%s" type' % (repr(self.value), self.type))
+        return Error.__str__(self) + (
+           ' - %r is not a valid value of "%s" type'
+           % (self.value, self.datatype))
 
 class NodeTypeError(Error):
     """Exception raised if the JSON object type doesn't fit the data model."""
@@ -50,7 +51,7 @@ class InvalidNodeError(Error):
     """Exception raised for nodes that are not found in the data model."""
 
     def __str__(self):
-        return (Error.__str__(self) + " - invalid node")
+        return Error.__str__(self) + " - invalid node"
 
 class MissingKeyError(Error):
     """Exception raised if a list entry doesn't have all keys."""
@@ -66,7 +67,7 @@ class InvalidAnnotationObjectError(Error):
     """Exception raise for an invalid annotation object."""
 
     def __str__(self):
-        return (Error.__str__(self) + " - invalid annotation object")
+        return Error.__str__(self) + " - invalid annotation object"
 
 class InvalidAnnotationError(Error):
     """
@@ -78,13 +79,14 @@ class InvalidAnnotationError(Error):
         self.annot = annot
 
     def __str__(self):
-        return (Error.__str__(self) + " - invalid annotation " + self.annot)
+        return Error.__str__(self) + " - invalid annotation " + self.annot
 
 class JSONError(Error):
     """Exception raised for broken JSON input."""
 
     def __str__(self):
-        return (self.path.__str__())
+        return "%s" % self.path
+
 
 class Translator (object):
     """Translate JSON to XML according to a YANG data model.
@@ -284,8 +286,8 @@ class Translator (object):
                 raise InvalidNodeError(path)
         if sep:
             self.node_modules.add(fst)
-            return (snd, fst, spec)
-        return (fst, ns, spec)
+            return snd, fst, spec
+        return fst, ns, spec
 
     def text_value(self, value, type_spec, mod_name, path):
         """Return `value` translated to its XML form.
@@ -428,7 +430,7 @@ def main():
         jtox = json.load(dfile)
     except IOError as e:
         sys.stderr.write("%s: error: %s: '%s'\n" %
-                         (parser.prog, e.strerror,e.filename))
+                         (parser.prog, e.strerror, e.filename))
         return 1
     except ValueError as e:
         sys.stderr.write("%s: error: %s\n" %
@@ -441,7 +443,7 @@ def main():
     try:
         trans.translate(jfile, root_el)
     except Error as e:
-        sys.stderr.write(parser.prog + ": " + str(e) + "\n")
+        sys.stderr.write("%s: %s\n" % (parser.prog, e))
         return e.return_value
     for m in set(trans.prefix) - trans.node_modules:
         root_el.attrib["xmlns:" + trans.prefix[m]] = trans.uri[m]

--- a/bin/pyang
+++ b/bin/pyang
@@ -176,7 +176,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
 
     (o, args) = optparser.parse_args()
 
-    if o.outfile != None and o.format == None:
+    if o.outfile is not None and o.format is None:
         sys.stderr.write("no format specified\n")
         sys.exit(1)
 
@@ -191,7 +191,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
             try:
                 fd = open(filenames[0], "rb")
             except IOError as ex:
-                sys.stderr.write("error %s: %s\n" % (filenames[0], str(ex)))
+                sys.stderr.write("error %s: %s\n" % (filenames[0], ex))
                 sys.exit(1)
         elif sys.version < "3":
             fd = sys.stdin
@@ -224,7 +224,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
 
     # make a map of features to support, per module
     if o.hello:
-        for (mn,rev) in hel.yang_modules():
+        for mn, rev in hel.yang_modules():
             ctx.features[mn] = hel.get_features(mn)
     for f in ctx.opts.features:
         (modulename, features) = parse_features_string(f)
@@ -233,7 +233,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
     for p in plugin.plugins:
         p.setup_ctx(ctx)
 
-    if o.list_errors == True:
+    if o.list_errors is True:
         for tag in error.error_codes:
             (level, fmt) = error.error_codes[tag]
             if error.is_warning(level):
@@ -264,7 +264,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
     if len(xform_objs) != len(o.transforms):
         sys.exit(1)
 
-    if o.format != None:
+    if o.format is not None:
         if o.format not in fmts:
             sys.stderr.write("unsupported format '%s'\n" % o.format)
             sys.exit(1)
@@ -287,7 +287,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
 
     if o.hello:
         ctx.capabilities = hel.registered_capabilities()
-        for (mn,rev) in hel.yang_modules():
+        for mn, rev in hel.yang_modules():
             mod = ctx.search_module(0, mn, rev)
             if mod is None:
                 emarg = mn
@@ -318,7 +318,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                 if o.verbose:
                     util.report_file_read(filename, "(CL)")
             except IOError as ex:
-                sys.stderr.write("error %s: %s\n" % (filename, str(ex)))
+                sys.stderr.write("error %s: %s\n" % (filename, ex))
                 sys.exit(1)
             except UnicodeDecodeError as ex:
                 s = str(ex).replace('utf-8', 'utf8')
@@ -327,9 +327,9 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
             m = syntax.re_filename.search(filename)
             ctx.yin_module_map = {}
             if m is not None:
-                (name, rev, format) = m.groups()
+                name, rev, in_format = m.groups()
                 name = os.path.basename(name)
-                module = ctx.add_module(filename, text, format, name, rev,
+                module = ctx.add_module(filename, text, in_format, name, rev,
                                         expect_failure_error=False)
             else:
                 module = ctx.add_module(filename, text)
@@ -350,7 +350,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
             fd = io.open(filename, "r", encoding="utf-8")
             text = fd.read()
         except IOError as ex:
-            sys.stderr.write("error %s: %s\n" % (filename, str(ex)))
+            sys.stderr.write("error %s: %s\n" % (filename, ex))
             sys.exit(1)
         except UnicodeDecodeError as ex:
             s = str(ex).replace('utf-8', 'utf8')
@@ -415,10 +415,10 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
     if o.ignore_errors:
         ctx.errors = []
 
-    for (epos, etag, eargs) in ctx.errors:
+    for epos, etag, eargs in ctx.errors:
         if etag in o.ignore_error_tags:
             continue
-        if (ctx.implicit_errors == False and
+        if (ctx.implicit_errors is False and
             hasattr(epos.top, 'i_modulename') and
             epos.top.arg not in modulenames and
             epos.top.i_modulename not in modulenames and
@@ -437,15 +437,12 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
         else:
             kind = "error"
             exit_code = 1
-        if o.print_error_code == True:
-            sys.stderr.write(str(epos) + ': %s: %s\n' % (kind, etag))
-        else:
-            sys.stderr.write(str(epos) + ': %s: ' % kind + \
-                                 error.err_to_str(etag, eargs) + '\n')
+        emsg = etag if o.print_error_code else error.err_to_str(etag, eargs)
+        sys.stderr.write('%s: %s: %s\n' % (epos, kind, emsg))
 
     if emit_obj is not None and len(modules) > 0:
         tmpfile = None
-        if o.outfile == None:
+        if o.outfile is None:
             if sys.version < '3':
                 fd = codecs.getwriter('utf8')(sys.stdout)
             else:
@@ -461,16 +458,16 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
         except error.EmitError as e:
             if e.msg != "":
                 sys.stderr.write(e.msg + '\n')
-            if tmpfile != None:
+            if tmpfile is not None:
                 fd.close()
                 os.remove(tmpfile)
             sys.exit(e.exit_code)
         except:
-            if tmpfile != None:
+            if tmpfile is not None:
                 fd.close()
                 os.remove(tmpfile)
             raise
-        if tmpfile != None:
+        if tmpfile is not None:
             fd.close()
             os.rename(tmpfile, o.outfile)
 
@@ -478,14 +475,14 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
 
 def parse_features_string(s):
     if s.find(':') == -1:
-        return (s, [])
+        return s, []
     else:
-        [modulename, rest] = s.split(':', 1)
+        modulename, rest = s.split(':', 1)
         if rest == '':
-            return (modulename, [])
+            return modulename, []
         else:
             features = rest.split(',')
-            return (modulename, features)
+            return modulename, features
 
 if __name__ == '__main__':
     run()

--- a/bin/yang2html
+++ b/bin/yang2html
@@ -70,13 +70,13 @@ if len(args) == 0:
 else:
     filename = args[0]
     try:
-        fd = file(filename)
+        fd = open(filename)
         buf = fd.read()
     except IOError as ex:
-        sys.stderr.write("error %s: %s\n" % (filename, str(ex)))
+        sys.stderr.write("error %s: %s\n" % (filename, ex))
         sys.exit(1)
 
-if o.outfile == None:
+if o.outfile is None:
     fd = sys.stdout
 else:
     fd = open(o.outfile, "w+")
@@ -119,7 +119,7 @@ else:
     fd.write(begin_yang)
 
 while i < len(buf):
-    if no_yang == True and buf[i:].startswith(begin_yang):
+    if no_yang and buf[i:].startswith(begin_yang):
         no_yang = False
         fd.write(buf[:i])
         if o.emit_css:
@@ -129,16 +129,16 @@ while i < len(buf):
         buf = buf[i+len(begin_yang):]
         i = 0
         continue
-    elif no_yang == True:
+    elif no_yang:
         i = i + 1
         continue
-    elif no_yang == False and buf[i:].startswith('</pre>'):
+    elif not no_yang and buf[i:].startswith('</pre>'):
         no_yang = True
         continue
     if q == '"' and buf[i] == '\\':
         i = i + 2
         continue
-    if q != None and buf[i] == q:
+    if q is not None and buf[i] == q:
         fd.write("<span class='str'>")
         fd.write(q)
         fd.write(escape(buf[:i+1]))
@@ -146,7 +146,7 @@ while i < len(buf):
         buf = buf[i+1:]
         q = None
         i = 0
-    elif q != None:
+    elif q is not None:
         i = i + 1
         continue
     if buf[i] == '/' and buf[i+1] == '/':
@@ -181,9 +181,9 @@ while i < len(buf):
         i = 0
     elif buf[i].isspace():
         i = i + 1
-    elif keyword_next == True:
+    elif keyword_next:
         m = pyang.syntax.re_keyword.match(buf, i)
-        if m != None:
+        if m is not None:
             kw = m.group()
             if kw in pyang.syntax.yin_map:
                 fd.write(buf[:i])

--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -53,7 +53,7 @@ class Context(object):
             revs = self.revs[mod]
             revs.append((rev, handle))
 
-    def add_module(self, ref, text, format=None,
+    def add_module(self, ref, text, in_format=None,
                    expect_modulename=None, expect_revision=None,
                    expect_failure_error=True):
         """Parse a module text and add the module data to the context
@@ -61,14 +61,14 @@ class Context(object):
         `ref` is a string which is used to identify the source of
               the text for the user.  used in error messages
         `text` is the raw text data
-        `format` is one of 'yang' or 'yin'.
+        `in_format` is one of 'yang' or 'yin'.
 
         Returns the parsed and validated module on success, and None on error.
         """
-        if format == None:
-            format = util.guess_format(text)
+        if in_format is None:
+            in_format = util.guess_format(text)
 
-        if format == 'yin':
+        if in_format == 'yin':
             p = yin_parser.YinParser()
         else:
             p = yang_parser.YangParser()
@@ -154,33 +154,34 @@ class Context(object):
         self._ensure_revs(revs)
         latest = None
         lhandle = None
-        for (rev, handle) in revs:
+        for rev, handle in revs:
             if rev is not None and (latest is None or rev > latest):
                 latest = rev
                 lhandle = handle
-        return (latest, lhandle)
+        return latest, lhandle
 
     def _ensure_revs(self, revs):
         i = 0
         length = len(revs)
+        repository = self.repository
         while i < length:
-            (rev, handle) = revs[i]
+            rev, handle = revs[i]
             if rev is None:
                 # now we must read the revision from the module
                 try:
-                    r = self.repository.get_module_from_handle(handle)
-                except self.repository.ReadError as ex:
+                    ref, in_format, text = repository.get_module_from_handle(
+                        handle)
+                except repository.ReadError as ex:
                     i += 1
                     continue
-                (ref, format, text) = r
 
-                if format == None:
-                    format = util.guess_format(text)
+                if in_format is None:
+                    in_format = util.guess_format(text)
 
-                if format == 'yin':
+                if in_format == 'yin':
                     yintext = text
-                    p = yin_parser.YinParser({'no_include':True,
-                                              'no_extensions':True})
+                    p = yin_parser.YinParser(
+                        {'no_include': True, 'no_extensions': True})
                 else:
                     yintext = None
                     p = yang_parser.YangParser()
@@ -203,7 +204,7 @@ class Context(object):
             # keep track of this to avoid multiple errors
             self.revs[modulename] = []
             return None
-        elif self.revs[modulename] == []:
+        elif not self.revs[modulename]:
             # this module doesn't exist in the repos at all, error reported
             return None
 
@@ -214,7 +215,7 @@ class Context(object):
             x = util.keysearch(revision, 0, self.revs[modulename])
             if x is not None:
                 (_revision, handle) = x
-                if handle == None:
+                if handle is None:
                     # this revision doesn't exist in the repos, error reported
                     return None
             else:
@@ -251,15 +252,15 @@ class Context(object):
         else:
             # get it from the repos
             try:
-                r = self.repository.get_module_from_handle(handle)
-                (ref, format, text) = r
-                module = self.add_module(ref, text, format,
-                                         modulename, revision)
+                ref, in_format, text = self.repository.get_module_from_handle(
+                    handle)
+                module = self.add_module(
+                    ref, text, in_format, modulename, revision)
             except self.repository.ReadError as ex:
                 error.err_add(self.errors, pos, 'READ_ERROR', str(ex))
                 module = None
 
-        if module == None:
+        if module is None:
             return None
         # if modulename != module.arg:
         #     error.err_add(self.errors, module.pos, 'BAD_MODULE_FILENAME',
@@ -284,7 +285,7 @@ class Context(object):
         if modulename not in self.revs:
             # this module doesn't exist in the repos at all
             return None
-        elif self.revs[modulename] == []:
+        elif not self.revs[modulename]:
             # this module doesn't exist in the repos at all, error reported
             return None
 
@@ -294,8 +295,8 @@ class Context(object):
             self._ensure_revs(self.revs[modulename])
             x = util.keysearch(revision, 1, self.revs[modulename])
             if x is not None:
-                (_revision, handle) = x
-                if handle == None:
+                _revision, handle = x
+                if handle is None:
                     # this revision doesn't exist in the repos, error reported
                     return None
             else:
@@ -313,12 +314,13 @@ class Context(object):
         else:
             # get it from the repos
             try:
-                r = self.repository.get_module_from_handle(handle)
-                (ref, format, text) = r
-                if format == None:
-                    format = util.guess_format(text)
+                ref, in_format, text = self.repository.get_module_from_handle(
+                    handle)
 
-                if format == 'yin':
+                if in_format is None:
+                    in_format = util.guess_format(text)
+
+                if in_format == 'yin':
                     p = yin_parser.YinParser(extra)
                 else:
                     p = yang_parser.YangParser(extra)
@@ -332,12 +334,12 @@ class Context(object):
         modules = []
         for k in self.modules:
             m = self.modules[k]
-            if m != None:
+            if m is not None:
                 modules.append(m)
         for m in modules:
             statements.validate_module(self, m)
             namespace = m.search_one('namespace')
-            if namespace != None:
+            if namespace is not None:
                 uri = namespace.arg
                 if uri in uris:
                     if uris[uri] != m.arg:
@@ -350,9 +352,6 @@ class Context(object):
 class Repository(object):
     """Abstract base class that represents a module repository"""
 
-    def __init__(self):
-        pass
-
     def get_modules_and_revisions(self, ctx):
         """Return a list of all modules and their revisons
 
@@ -364,10 +363,10 @@ class Repository(object):
     def get_module_from_handle(self, handle):
         """Return the raw module text from the repository
 
-        Returns (`ref`, `format`, `text`) if found, or None if not found.
+        Returns (`ref`, `in_format`, `text`) if found, or None if not found.
         `ref` is a string which is used to identify the source of
               the text for the user.  used in error messages
-        `format` is one of 'yang' or 'yin' or None.
+        `in_format` is one of 'yang' or 'yin' or None.
         `text` is the raw text data
 
         Raises `ReadError`
@@ -376,8 +375,6 @@ class Repository(object):
     class ReadError(Exception):
         """Signals that an error occured during module retrieval"""
 
-        def __init__(self, str):
-            Exception.__init__(self, str)
 
 class FileRepository(Repository):
     def __init__(self, path="", use_env=True, no_path_recurse=False,
@@ -452,12 +449,12 @@ class FileRepository(Repository):
                 if os.path.isfile(absfilename):
                     m = syntax.re_filename.search(fname)
                     if m is not None:
-                        (name, rev, format) = m.groups()
+                        name, rev, in_format = m.groups()
                         if not os.access(absfilename, os.R_OK):
                             continue
                         if absfilename.startswith("./"):
                             absfilename = absfilename[2:]
-                        handle = (format, absfilename)
+                        handle = in_format, absfilename
                         self.modules.append((name, rev, handle))
                 elif (not self.no_path_recurse
                       and d != '.' and os.path.isdir(absfilename)):
@@ -465,41 +462,13 @@ class FileRepository(Repository):
         for d in self.dirs:
             add_files_from_dir(d)
 
-    # FIXME: bad strategy; when revisions are not used in the filename
-    # this code parses all modules :(  need to do this lazily
-    # FIXME: actually this function is never called and can be deleted
-    def _peek_revision(self, absfilename, format, ctx):
-        fd = None
-        try:
-            fd = io.open(absfilename, "r", encoding="utf-8")
-            text = fd.read()
-        except IOError as ex:
-            return None
-        except UnicodeDecodeError as ex:
-            return None
-        finally:
-            if fd is not None:
-                fd.close()
-
-        if format == 'yin':
-            p = yin_parser.YinParser()
-        else:
-            p = yang_parser.YangParser()
-
-        # FIXME: optimization - do not parse the entire text
-        # just to read the revisions...
-        module = p.parse(ctx, absfilename, text)
-        if module is None:
-            return None
-        return (util.get_latest_revision(module), module)
-
     def get_modules_and_revisions(self, ctx):
         if self.modules is None:
             self._setup(ctx)
         return self.modules
 
     def get_module_from_handle(self, handle):
-        (format, absfilename) = handle
+        in_format, absfilename = handle
         fd = None
         try:
             fd = io.open(absfilename, "r", encoding="utf-8")
@@ -507,14 +476,14 @@ class FileRepository(Repository):
             if self.verbose:
                 util.report_file_read(absfilename)
         except IOError as ex:
-            raise self.ReadError(absfilename + ": " + str(ex))
+            raise self.ReadError("%s: %s" % (absfilename, ex))
         except UnicodeDecodeError as ex:
             s = str(ex).replace('utf-8', 'utf8')
-            raise self.ReadError(absfilename + ": unicode error: " + s)
+            raise self.ReadError("%s: unicode error: %s" % (absfilename, s))
         finally:
             if fd is not None:
                 fd.close()
 
-        if format is None:
-            format = util.guess_format(text)
-        return (absfilename, format, text)
+        if in_format is None:
+            in_format = util.guess_format(text)
+        return absfilename, in_format, text

--- a/pyang/error.py
+++ b/pyang/error.py
@@ -526,7 +526,7 @@ def err_to_str(tag, args):
 def err_add(errors, pos, tag, args):
     error = (copy.copy(pos), tag, args)
     # surely this can be done more elegant??
-    for (p, t, a) in errors:
+    for p, t, a in errors:
         if (p.line == pos.line and p.ref == pos.ref and
             p.top == pos.top and t == tag and a == args):
             return

--- a/pyang/hello.py
+++ b/pyang/hello.py
@@ -18,11 +18,11 @@ class Capability:
     def __init__(self, uri):
         self.parameters = {}
         if "?" in uri:
-            id, pars = uri.split("?")
+            id_, pars = uri.split("?")
             self.parse_pars(pars)
         else:
-            id = uri
-        self.id = id
+            id_ = uri
+        self.id = id_
 
     def parse_pars(self,pars):
         for p in pars.split("&"):

--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -160,7 +160,7 @@ def check_update(ctx, newmod):
             fd = io.open(oldfilename, "r", encoding="utf-8")
             text = fd.read()
         except IOError as ex:
-            sys.stderr.write("error %s: %s\n" % (oldfilename, str(ex)))
+            sys.stderr.write("error %s: %s\n" % (oldfilename, ex))
             sys.exit(1)
         if oldfilename in ctx.opts.old_deviation:
             oldctx.add_module(oldfilename, text)
@@ -173,9 +173,9 @@ def check_update(ctx, newmod):
     if oldmod is None:
         return
 
-    for (epos, etag, eargs) in ctx.errors:
-        if (epos.ref in (newmod.pos.ref, oldmod.pos.ref) and \
-                error.is_error(error.err_level(etag))):
+    for epos, etag, eargs in ctx.errors:
+        if (epos.ref in (newmod.pos.ref, oldmod.pos.ref)
+            and error.is_error(error.err_level(etag))):
             return
 
     if ctx.opts.verbose:
@@ -449,10 +449,10 @@ def chk_if_feature(old, new, ctx):
             err_def_added2(s, new, ctx)
 
 def chk_config(old, new, ctx):
-    if old.i_config == False and new.i_config == True:
+    if not old.i_config and new.i_config:
         if statements.is_mandatory_node(new):
             err_add(ctx.errors, new.pos, 'CHK_MANDATORY_CONFIG', new.arg)
-    elif old.i_config == True and new.i_config == False:
+    elif old.i_config and not new.i_config:
         err_add(ctx.errors, new.pos, 'CHK_BAD_CONFIG', new.arg)
 
 def chk_must(old, new, ctx):
@@ -577,14 +577,8 @@ def chk_key(old, new, ctx):
         if len(oldks) != len(newks):
             err_def_changed(oldkey, newkey, ctx)
         else:
-            def name(x):
-                if x.find(":") == -1:
-                    return x
-                else:
-                    [prefix, name] = x.split(':', 1)
-                    return name
-            for (ok, nk) in zip(oldks, newks):
-                if name(ok) != name(nk):
+            for ok, nk in zip(oldks, newks):
+                if util.split_identifier(ok)[1] != util.split_identifier(nk)[1]:
                     err_def_changed(oldkey, newkey, ctx)
                     return
 
@@ -594,9 +588,9 @@ def chk_unique(old, new, ctx):
     if not hasattr(old, 'i_unique') or not hasattr(new, 'i_unique'):
         return
     oldunique = []
-    for (u, l) in old.i_unique:
+    for u, l in old.i_unique:
         oldunique.append((u, [s.arg for s in l]))
-    for (u, l) in new.i_unique:
+    for u, l in new.i_unique:
         # check if this unique was present before
         o = util.keysearch([s.arg for s in l], 1, oldunique)
         if o is not None:
@@ -661,7 +655,7 @@ def chk_range(old, new, oldts, newts, ctx):
     if isinstance(ots, types.RangeTypeSpec):
         tmperrors = []
         types.validate_ranges(tmperrors, new.pos, ots.ranges, new)
-        if tmperrors != []:
+        if tmperrors:
             err_add(ctx.errors, new.pos, 'CHK_RESTRICTION_CHANGED',
                     'range')
     else:
@@ -690,7 +684,7 @@ def chk_string(old, new, oldts, newts, ctx):
 
 def chk_enumeration(old, new, oldts, newts, ctx):
     # verify that all old enums are still in new, with the same values
-    for (name, val) in oldts.enums:
+    for name, val in oldts.enums:
         n = util.keysearch(name, 0, newts.enums)
         if n is None:
             err_add(ctx.errors, new.pos, 'CHK_DEF_REMOVED',
@@ -701,7 +695,7 @@ def chk_enumeration(old, new, oldts, newts, ctx):
 
 def chk_bits(old, new, oldts, newts, ctx):
     # verify that all old bits are still in new, with the same positions
-    for (name, pos) in oldts.bits:
+    for name, pos in oldts.bits:
         n = util.keysearch(name, 0, newts.bits)
         if n is None:
             err_add(ctx.errors, new.pos, 'CHK_DEF_REMOVED',
@@ -753,7 +747,7 @@ def chk_union(old, new, oldts, newts, ctx):
     if len(newts.types) != len(oldts.types):
         err_add(ctx.errors, new.pos, 'CHK_UNION_TYPES', ())
     else:
-        for (o,n) in zip(oldts.types, newts.types):
+        for o, n in zip(oldts.types, newts.types):
             chk_type(o, n, ctx)
 
 def chk_dummy(old, new, oldts, newts, ctx):

--- a/pyang/plugins/depend.py
+++ b/pyang/plugins/depend.py
@@ -55,7 +55,7 @@ class DependPlugin(plugin.PyangPlugin):
     def emit(self, ctx, modules, fd):
         # cannot do this unless everything is ok for our module
         modulenames = [m.arg for m in modules]
-        for (epos, etag, eargs) in ctx.errors:
+        for epos, etag, eargs in ctx.errors:
             if ((epos.top is None or epos.top.arg in modulenames) and
                 error.is_error(error.err_level(etag))):
                 raise error.EmitError("%s contains errors" % epos.top.arg)

--- a/pyang/plugins/jsonxsl.py
+++ b/pyang/plugins/jsonxsl.py
@@ -68,7 +68,7 @@ class JsonXslPlugin(plugin.PyangPlugin):
         recursively all nodes in all data trees, and finally emit the
         serialized stylesheet.
         """
-        for (epos, etag, eargs) in ctx.errors:
+        for epos, etag, eargs in ctx.errors:
             if error.is_error(error.err_level(etag)):
                 raise error.EmitError("JSONXSL plugin needs a valid module")
         self.real_prefix = unique_prefixes(ctx)

--- a/pyang/plugins/jstree.py
+++ b/pyang/plugins/jstree.py
@@ -536,7 +536,7 @@ def get_flags_str(s):
         return ''
     elif s.keyword == 'notification':
         return ''
-    elif s.i_config == True:
+    elif s.i_config:
         return 'config'
     else:
         return 'no config'
@@ -605,11 +605,7 @@ def typestring(node):
         # chase typedef
         type_namespace = None
         i_type_name = None
-        name = t.arg
-        if name.find(":") == -1:
-            prefix = None
-        else:
-            [prefix, name] = name.split(':', 1)
+        prefix, name = util.split_identifier(t.arg)
         if prefix is None or t.i_module.i_prefix == prefix:
             # check local typedefs
             pmodule = node.i_module
@@ -621,7 +617,7 @@ def typestring(node):
             if pmodule is None:
                 return
             typedef = statements.search_typedef(pmodule, name)
-        if typedef != None:
+        if typedef is not None:
             s = s + get_nontypedefstring(typedef)
     return s
 

--- a/pyang/plugins/jtox.py
+++ b/pyang/plugins/jtox.py
@@ -40,7 +40,7 @@ class JtoXPlugin(plugin.PyangPlugin):
     def emit(self, ctx, modules, fd):
         """Main control function.
         """
-        for (epos, etag, eargs) in ctx.errors:
+        for epos, etag, eargs in ctx.errors:
             if error.is_error(error.err_level(etag)):
                 raise error.EmitError("JTOX plugin needs a valid module")
         tree = {}
@@ -86,19 +86,19 @@ class JtoXPlugin(plugin.PyangPlugin):
             modname = ch.i_module.i_modulename
             parent[nodename] = ndata
 
-    def base_type(self, type):
-        """Return the base type of `type`."""
+    def base_type(self, of_type):
+        """Return the base type of `of_type`."""
         while 1:
-            if type.arg == "leafref":
-                node = type.i_type_spec.i_target_node
-            elif type.i_typedef is None:
+            if of_type.arg == "leafref":
+                node = of_type.i_type_spec.i_target_node
+            elif of_type.i_typedef is None:
                 break
             else:
-                node = type.i_typedef
-            type = node.search_one("type")
-        if type.arg == "decimal64":
-            return [type.arg, int(type.search_one("fraction-digits").arg)]
-        elif type.arg == "union":
-            return [type.arg, [self.base_type(x) for x in type.i_type_spec.types]]
+                node = of_type.i_typedef
+            of_type = node.search_one("type")
+        if of_type.arg == "decimal64":
+            return [of_type.arg, int(of_type.search_one("fraction-digits").arg)]
+        elif of_type.arg == "union":
+            return [of_type.arg, [self.base_type(x) for x in of_type.i_type_spec.types]]
         else:
-            return type.arg
+            return of_type.arg

--- a/pyang/plugins/lint.py
+++ b/pyang/plugins/lint.py
@@ -241,7 +241,7 @@ def v_chk_recommended_substmt(ctx, stmt):
                         (s, stmt.keyword, r))
 
 def v_chk_namespace(ctx, stmt, namespace_prefixes):
-    if namespace_prefixes != []:
+    if namespace_prefixes:
         for prefix in namespace_prefixes:
             if stmt.arg == prefix + stmt.i_module.arg:
                 return
@@ -249,9 +249,9 @@ def v_chk_namespace(ctx, stmt, namespace_prefixes):
                 namespace_prefixes[0] + stmt.i_module.arg)
 
 def v_chk_module_name(ctx, stmt, modulename_prefixes):
-    if modulename_prefixes != []:
+    if modulename_prefixes:
         for prefix in modulename_prefixes:
-            if stmt.arg.find(prefix + '-') == 0:
+            if stmt.arg.startswith(prefix + '-'):
                 return
         if len(modulename_prefixes) == 1:
             err_add(ctx.errors, stmt.pos, 'LINT_BAD_MODULENAME_PREFIX_1',
@@ -263,7 +263,7 @@ def v_chk_module_name(ctx, stmt, modulename_prefixes):
             s = ", ".join(['"' + p + '-"' for p in modulename_prefixes[:-1]]) +\
             ', or "' + modulename_prefixes[-1] + '-"'
             err_add(ctx.errors, stmt.pos, 'LINT_BAD_MODULENAME_PREFIX_N', s)
-    elif stmt.arg.find('-') == -1:
+    elif '-' not in stmt.arg:
         # can't check much, but we can check that a prefix is used
         err_add(ctx.errors, stmt.pos, 'LINT_NO_MODULENAME_PREFIX', ())
 
@@ -294,14 +294,13 @@ def v_chk_mandatory_top_level(ctx, stmt):
 
 def v_chk_hyphenated_names(ctx, stmt):
     if stmt.keyword in grammar.stmt_map:
-        (arg_type, subspec) = grammar.stmt_map[stmt.keyword]
-        if ((arg_type == 'identifier' or arg_type == 'enum-arg') and
-            not_hyphenated(stmt.arg)):
+        arg_type, subspec = grammar.stmt_map[stmt.keyword]
+        if arg_type in ('identifier', 'enum-arg') and not_hyphenated(stmt.arg):
             error.err_add(ctx.errors, stmt.pos, 'LINT_NOT_HYPHENATED', stmt.arg)
 
 def not_hyphenated(name):
     ''' Returns True if name is not hyphenated '''
-    if name == None:
+    if name is None:
         return False
     # Check for upper-case and underscore
-    return (name != name.lower() or "_" in name)
+    return name != name.lower() or "_" in name

--- a/pyang/plugins/metadata.py
+++ b/pyang/plugins/metadata.py
@@ -22,7 +22,7 @@ def pyang_plugin_init():
     grammar.register_extension_module(md_module_name)
 
     # Register the special grammar
-    for (stmt, occurance, (arg, rules), add_to_stmts) in md_stmts:
+    for stmt, occurance, (arg, rules), add_to_stmts in md_stmts:
         grammar.add_stmt((md_module_name, stmt), (arg, rules))
         grammar.add_to_stmts_rules(add_to_stmts,
                                    [((md_module_name, stmt), occurance)])

--- a/pyang/plugins/omni.py
+++ b/pyang/plugins/omni.py
@@ -89,7 +89,7 @@ def post_process(fd, ctx):
     for s in leafrefs:
         # dont try to connect to class not given as input to pyang
 
-        if (s.strip().split(" to ")[1].split(" with ")[0]in paths_in_module):
+        if s.strip().split(" to ")[1].split(" with ")[0] in paths_in_module:
             fd.write(s)
 
 
@@ -162,7 +162,7 @@ def print_attributes(s,fd, ctx):
         for ch in s.i_children:
             index = False
             if ch.keyword in ["leaf", "leaf-list"]:
-                if found_attrs == False:
+                if not found_attrs:
                     # first attr in attr section
                     fd.write("make new shape at end of graphics with properties {autosizing:full, size:{187.5, 28.0}, text:{")
                     found_attrs = True
@@ -170,12 +170,12 @@ def print_attributes(s,fd, ctx):
                     # comma before new textitem
                     fd.write(", ")
                 if ch.keyword == "leaf-list":
-                    str = "[]"
+                    append = "[]"
                 else:
-                    str = ""
+                    append = ""
                 if ch.arg in key:
                     index = True
-                print_leaf(ch, str, index, fd, ctx)
+                print_leaf(ch, append, index, fd, ctx)
         if found_attrs:
             # close attr section
             fd.write("}, text placement:top, origin:{150.0, 25.5}, vertical padding:0}\n")
@@ -183,7 +183,7 @@ def print_attributes(s,fd, ctx):
         # Search actions
         for ch in s.i_children:
             if ch.keyword == ('tailf-common', 'action'):
-                if found_actions == False:
+                if not found_actions:
                     fd.write("make new shape at end of graphics with properties {autosizing:full, size:{187.5, 28.0}, text:{text:\"")
                     found_actions = True
                 print_action(ch, fd, ctx)
@@ -194,19 +194,20 @@ def print_attributes(s,fd, ctx):
         return (found_attrs + found_actions) + 1
 
 def close_class(number, s, fd, ctx):
-    fd.write("local %s\n" %fullpath(s))
-    fd.write("set %s to assemble ( graphics -%s through -1 ) table shape {%s, 1}\n" %(fullpath(s), str(number), str(number) ))
+    fd.write("local %s\n" % fullpath(s))
+    fd.write("set %s to assemble ( graphics -%s through -1 ) table shape {%s, 1}\n"
+             % (fullpath(s), number, number))
 
 
 def print_node(parent, s, module, fd, path, ctx, root='false'):
     # We have a class
-    if (s.keyword in class_keywords):
+    if s.keyword in class_keywords:
         print_class_header(s, fd, ctx, root)
         paths_in_module.append(fullpath(s))
         print_class_stuff(s, fd, ctx)
 
         #  Do not try to create relationship to module
-        if (parent != module):
+        if parent != module:
             presence = s.search_one("presence")
             if presence is not None:
                 print_aggregation(parent, s, fd, "0", "1", ctx)
@@ -243,9 +244,9 @@ def print_notification(notification, fd, ctx, root='false'):
 def print_inout(parent, s, fd, ctx, root='false'):
     fd.write("<UML:Class xmi.id = \'%s\' name = \'%s-%s\' " %(fullpath(s), parent.arg, s.keyword))
 
-def print_leaf(leaf, str, index, fd, ctx):
+def print_leaf(leaf, append, index, fd, ctx):
 
-    if leaf.i_config == True:
+    if leaf.i_config:
         c =  '(rw)'
         color = optionalconfig
     else:
@@ -259,9 +260,11 @@ def print_leaf(leaf, str, index, fd, ctx):
         mand = ''
         color = mandatoryconfig
     if not index:
-        fd.write("{font: \"Helvetica-Oblique\", color: %s, text: \"%s%s%s %s %s\n\"}" %(color, leaf.arg, str, mand, c, get_typename(leaf)))
+        fd.write("{font: \"Helvetica-Oblique\", color: %s, text: \"%s%s%s %s %s\n\"}"
+                 % (color, leaf.arg, append, mand, c, get_typename(leaf)))
     else:
-        fd.write("{font: \"Helvetica-Oblique\", color: %s, underlined: true, text: \"%s%s%s %s %s\n\"}" %(color, leaf.arg, str, mand, c, get_typename(leaf)))
+        fd.write("{font: \"Helvetica-Oblique\", color: %s, underlined: true, text: \"%s%s%s %s %s\n\"}"
+                 % (color, leaf.arg, append, mand, c, get_typename(leaf)))
 
 
 def print_association(fromclass, toclass, fromleaf, toleaf, association, fd, ctx):
@@ -294,8 +297,8 @@ def fullpath(stmt):
     pathsep = "_"
     path = stmt.arg
     # for augment paths we need to remove initial /
-    if path.find("/") == 0:
-        path = path[1:len(path)]
+    if path.startswith("/"):
+        path = path[1:]
     else:
         if stmt.keyword == 'case':
             path = path + '-case'

--- a/pyang/plugins/restconf.py
+++ b/pyang/plugins/restconf.py
@@ -32,7 +32,7 @@ def pyang_plugin_init():
     statements.add_keywords_with_no_explicit_config(yd)
 
     # Register the special grammar
-    for (stmt, occurance, (arg, rules), add_to_stmts) in restconf_stmts:
+    for stmt, occurance, (arg, rules), add_to_stmts in restconf_stmts:
         grammar.add_stmt((restconf_module_name, stmt), (arg, rules))
         grammar.add_to_stmts_rules(add_to_stmts,
                                    [((restconf_module_name, stmt), occurance)])

--- a/pyang/plugins/sample-xml-skeleton.py
+++ b/pyang/plugins/sample-xml-skeleton.py
@@ -90,7 +90,7 @@ class SampleXMLSkeletonPlugin(plugin.PyangPlugin):
         else:
             path = []
 
-        for (epos, etag, eargs) in ctx.errors:
+        for epos, etag, eargs in ctx.errors:
             if error.is_error(error.err_level(etag)):
                 raise error.EmitError(
                     "sample-xml-skeleton plugin needs a valid module")
@@ -204,7 +204,7 @@ class SampleXMLSkeletonPlugin(plugin.PyangPlugin):
         """
         if path is None:
             return parent, module, None
-        elif path == []:
+        elif not path:
             # GO ON
             pass
         else:

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -96,7 +96,7 @@ class SidPlugin(plugin.PyangPlugin):
             if not error.is_warning(error.err_level(etag)):
                 fatal_error = True
 
-        if fatal_error or (ctx.errors != [] and ctx.opts.check_sid_file is not None):
+        if fatal_error or ctx.errors and ctx.opts.check_sid_file is not None:
             sys.stderr.write("Invalid YANG module\n")
             return
 

--- a/pyang/plugins/smi.py
+++ b/pyang/plugins/smi.py
@@ -49,7 +49,7 @@ def pyang_plugin_init():
     grammar.register_extension_module(smi_module_name)
 
     # Register the special grammar
-    for (stmt, occurance, (arg, rules), add_to_stmts) in smi_stmts:
+    for stmt, occurance, (arg, rules), add_to_stmts in smi_stmts:
         grammar.add_stmt((smi_module_name, stmt), (arg, rules))
         grammar.add_to_stmts_rules(add_to_stmts,
                                    [((smi_module_name, stmt), occurance)])

--- a/pyang/plugins/tree.py
+++ b/pyang/plugins/tree.py
@@ -11,6 +11,7 @@ import re
 
 from pyang import plugin
 from pyang import statements
+from pyang import util
 
 def pyang_plugin_init():
     plugin.register_plugin(TreePlugin())
@@ -458,9 +459,9 @@ def get_flags_str(s, mode):
         return '-n'
     elif s.keyword == 'uses':
         return '-u'
-    elif s.i_config == True:
+    elif s.i_config is True:
         return 'rw'
-    elif s.i_config == False or mode == 'output' or mode == 'notification':
+    elif s.i_config is False or mode in ('output', 'notification'):
         return 'ro'
     else:
         return ''
@@ -485,17 +486,14 @@ def get_typename(s, prefix_with_modname=False):
                 target = []
                 curprefix = s.i_module.i_prefix
                 for name in p.arg.split('/'):
-                    if name.find(":") == -1:
-                        prefix = curprefix
-                    else:
-                        [prefix, name] = name.split(':', 1)
-                    if prefix == curprefix:
+                    prefix, name = util.split_identifier(name)
+                    if prefix is None or prefix == curprefix:
                         target.append(name)
                     else:
                         if prefix_with_modname:
                             if prefix in s.i_module.i_prefixes:
                                 # Try to map the prefix to the module name
-                                (module_name, _) = s.i_module.i_prefixes[prefix]
+                                module_name, _ = s.i_module.i_prefixes[prefix]
                             else:
                                 # If we can't then fall back to the prefix
                                 module_name = prefix
@@ -509,16 +507,15 @@ def get_typename(s, prefix_with_modname=False):
                 # leafref type. See RFC6020 section 9.9.2
                 # (https://tools.ietf.org/html/rfc6020#section-9.9.2)
                 if prefix_with_modname:
-                    if t.arg.find(":") == -1:
+                    prefix, name = util.split_identifier(t.arg)
+                    if prefix is None:
                         # No prefix specified. Leave as is
                         return t.arg
                     else:
                         # Prefix found. Replace it with the module name
-                        [prefix, name] = t.arg.split(':', 1)
-                        #return s.i_module.i_modulename + ':' + name
                         if prefix in s.i_module.i_prefixes:
                             # Try to map the prefix to the module name
-                            (module_name, _) = s.i_module.i_prefixes[prefix]
+                            module_name, _ = s.i_module.i_prefixes[prefix]
                         else:
                             # If we can't then fall back to the prefix
                             module_name = prefix
@@ -527,16 +524,15 @@ def get_typename(s, prefix_with_modname=False):
                     return t.arg
         else:
             if prefix_with_modname:
-                if t.arg.find(":") == -1:
+                prefix, name = util.split_identifier(t.arg)
+                if prefix is None:
                     # No prefix specified. Leave as is
                     return t.arg
                 else:
                     # Prefix found. Replace it with the module name
-                    [prefix, name] = t.arg.split(':', 1)
-                    #return s.i_module.i_modulename + ':' + name
                     if prefix in s.i_module.i_prefixes:
                         # Try to map the prefix to the module name
-                        (module_name, _) = s.i_module.i_prefixes[prefix]
+                        module_name, _ = s.i_module.i_prefixes[prefix]
                     else:
                         # If we can't then fall back to the prefix
                         module_name = prefix

--- a/pyang/syntax.py
+++ b/pyang/syntax.py
@@ -209,7 +209,7 @@ def chk_fraction_digits_arg(s):
         return False
 
 def chk_if_feature_expr(s):
-    return  parse_if_feature_expr(s) != None
+    return parse_if_feature_expr(s) is not None
 
 # if-feature-expr     = "(" if-feature-expr ")" /
 #                      if-feature-expr sep boolean-operator sep
@@ -253,7 +253,7 @@ def parse_if_feature_expr(s):
             y()
             tok = sx.get_token()
         sx.push_token(tok)
-        while operators[-1] != None:
+        while operators[-1] is not None:
             pop_operator()
 
     def y():

--- a/pyang/translators/dsdl.py
+++ b/pyang/translators/dsdl.py
@@ -95,7 +95,7 @@ class DSDLPlugin(plugin.PyangPlugin):
         emit_dsdl(ctx, modules, fd)
 
 def emit_dsdl(ctx, modules, fd):
-    for (epos, etag, eargs) in ctx.errors:
+    for epos, etag, eargs in ctx.errors:
         if error.is_error(error.err_level(etag)):
             raise error.EmitError("DSDL translation needs a valid module")
     schema = HybridDSDLSchema().from_modules(modules,
@@ -1211,9 +1211,9 @@ class HybridDSDLSchema(object):
                 self.add_patch(pset, sub)
         if expand:
             self.lookup_expand(grp, list(pset))
-        elif len(self.prefix_stack) <= 1 and not(hasattr(stmt,"d_expand")):
-            uname, dic = self.unique_def_name(stmt.i_grouping,
-                                              not(p_elem.interleave))
+        elif len(self.prefix_stack) <= 1 and not hasattr(stmt,"d_expand"):
+            uname, dic = self.unique_def_name(
+                stmt.i_grouping, not p_elem.interleave)
             if uname not in dic:
                 self.install_def(uname, stmt.i_grouping, dic,
                                  p_elem.interleave)

--- a/pyang/translators/schemanode.py
+++ b/pyang/translators/schemanode.py
@@ -139,7 +139,7 @@ class SchemaNode(object):
 
     def adjust_interleave(self, interleave):
         """Inherit interleave status from parent if undefined."""
-        if interleave == None and self.parent:
+        if interleave is None and self.parent:
             self.interleave = self.parent.interleave
         else:
             self.interleave = interleave

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -170,13 +170,13 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
         # the arg
         line_len = len(indent) + len(keywordstr) + 1 + 2 + len(eol)
         if (stmt.keyword in _keyword_prefer_single_quote_arg and
-            stmt.arg.find("'") == -1):
+            "'" not in stmt.arg):
             # print with single quotes
             if hasattr(stmt, 'arg_substrings') and len(stmt.arg_substrings) > 1:
                 # the arg was already split into multiple lines, keep them
                 emit_multi_str_arg(keywordstr, stmt.arg_substrings, fd, "'",
                                    indent, indentstep, max_line_len, line_len)
-            elif not(need_new_line(max_line_len, line_len, stmt.arg)):
+            elif not need_new_line(max_line_len, line_len, stmt.arg):
                 # fits into a single line
                 fd.write(" '" + stmt.arg + "'")
             else:
@@ -204,7 +204,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
                 (arg_type in _maybe_quote_arg_type and
                  not need_quote(stmt.arg))):
                 # minus 2 since we don't quote
-                if not(need_new_line(max_line_len, line_len-2, stmt.arg)):
+                if not need_new_line(max_line_len, line_len-2, stmt.arg):
                     fd.write(' ' + stmt.arg)
                 else:
                     fd.write('\n' + indent + indentstep + stmt.arg)
@@ -238,7 +238,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
             prev_kwd = s.keyword
         fd.write(indent + '}\n')
 
-    if (not(islast) and
+    if (not islast and
         ((level == 1 and stmt.keyword in
           _keyword_with_trailing_blank_line_toplevel) or
          stmt.keyword in _keyword_with_trailing_blank_line)):
@@ -248,7 +248,7 @@ def need_new_line(max_line_len, line_len, arg):
     eol = arg.find('\n')
     if eol == -1:
         eol = len(arg)
-    if (max_line_len is not None and line_len + eol > max_line_len):
+    if max_line_len is not None and line_len + eol > max_line_len:
         return True
     else:
         return False
@@ -260,7 +260,7 @@ def emit_multi_str_arg(keywordstr, strs, fd, pref_q,
     # we can print w/o a newline
     need_new_line = False
     if max_line_len is not None:
-        for (s, q) in strs:
+        for s, q in strs:
             q = select_quote(s, q, pref_q)
             if q == '"':
                 s = escape_str(s)
@@ -280,7 +280,7 @@ def emit_multi_str_arg(keywordstr, strs, fd, pref_q,
         s = escape_str(s)
     fd.write("%s%s%s\n" % (q, s, q))
     # then print the rest with the prefix and a newline at the end
-    for (s, q) in strs[1:-1]:
+    for s, q in strs[1:-1]:
         q = select_quote(s, q, pref_q)
         if q == '"':
             s = escape_str(s)
@@ -298,7 +298,7 @@ def select_quote(s, q, pref_q):
     if pref_q == q:
         return q
     elif pref_q == "'":
-        if s.find("'") == -1:
+        if "'" not in s:
             # the string was double quoted, but it wasn't necessary,
             # use preferred single quote
             return "'"
@@ -327,7 +327,7 @@ def emit_path_arg(keywordstr, arg, fd, indent, max_line_len, line_len, eol):
 
     arg = escape_str(arg)
 
-    if not(need_new_line(max_line_len, line_len, arg)):
+    if not need_new_line(max_line_len, line_len, arg):
         fd.write(" " + quote + arg + quote)
         return False
 

--- a/pyang/translators/yin.py
+++ b/pyang/translators/yin.py
@@ -116,7 +116,7 @@ def emit_stmt(ctx, module, stmt, fd, indent, indentstep):
     else:
         (argname, argiselem) = syntax.yin_map[stmt.raw_keyword]
         tag = stmt.raw_keyword
-    if argiselem == False or argname is None:
+    if argiselem is False or argname is None:
         if argname is None:
             attr = ''
         else:

--- a/pyang/types.py
+++ b/pyang/types.py
@@ -24,8 +24,8 @@ class TypeSpec(object):
         self.name = name
         self.base = None
 
-    def str_to_val(self, errors, pos, str):
-        return str
+    def str_to_val(self, errors, pos, string):
+        return string
 
     def validate(self, errors, pos, val, errstr=''):
         return True
@@ -34,27 +34,27 @@ class TypeSpec(object):
         return []
 
 class IntTypeSpec(TypeSpec):
-    def __init__(self, name, min, max):
+    def __init__(self, name, minimum, maximum):
         TypeSpec.__init__(self, name)
         self.is_int = True
-        self.min = min
-        self.max = max
+        self.min = minimum
+        self.max = maximum
 
-    def str_to_val(self, errors, pos, s):
+    def str_to_val(self, errors, pos, string):
         try:
-            if len(s) > 1 and s[0] == '0' and s[1] != 'x':
+            if len(string) > 1 and string[0] == '0' and string[1] != 'x':
                 # positive octal
-                s = s[:1] + 'o' + s[1:]
-            elif len(s) > 2 and s[0] == '-' and s[1] == '0' and s[2] != 'x':
+                string = string[:1] + 'o' + string[1:]
+            elif len(string) > 2 and string[0] == '-' and string[1] == '0' and string[2] != 'x':
                 # negative octal
-                s = s[:2] + 'o' + s[2:]
-            return int(s, 0)
+                string = string[:2] + 'o' + string[2:]
+            return int(string, 0)
         except ValueError:
             err_add(errors, pos, 'TYPE_VALUE',
-                    (s, self.definition, 'not an integer'))
+                    (string, self.definition, 'not an integer'))
             return None
 
-    def validate(self, errors, pos, val, errstr = ''):
+    def validate(self, errors, pos, val, errstr=''):
         if val < self.min or val > self.max:
             err_add(errors, pos, 'TYPE_VALUE',
                     (str(val), self.definition, 'range error' + errstr))
@@ -129,18 +129,18 @@ class Decimal64TypeSpec(TypeSpec):
         self.min = Decimal64Value(-9223372036854775808, fd=self.fraction_digits)
         self.max = Decimal64Value(9223372036854775807, fd=self.fraction_digits)
 
-    def str_to_val(self, errors, pos, s0):
+    def str_to_val(self, errors, pos, string):
         # make sure it is syntactically correct
-        if syntax.re_decimal.search(s0) is None:
+        if syntax.re_decimal.search(string) is None:
             err_add(errors, pos, 'TYPE_VALUE',
-                    (s0, self.definition, 'not a decimal'))
+                    (string, self.definition, 'not a decimal'))
             return None
-        if s0[0] == '-':
+        if string[0] == '-':
             is_negative = True
-            s = s0[1:]
+            s = string[1:]
         else:
             is_negative = False
-            s = s0
+            s = string
         p = s.find('.')
         if p == -1:
             v = int(s)
@@ -167,9 +167,9 @@ class Decimal64TypeSpec(TypeSpec):
                 return None
         if is_negative:
             v = -v
-        return Decimal64Value(v, s=s0)
+        return Decimal64Value(v, s=string)
 
-    def validate(self, errors, pos, val, errstr = ''):
+    def validate(self, errors, pos, val, errstr=''):
         if val < self.min or val > self.max:
             err_add(errors, pos, 'TYPE_VALUE',
                     (str(val), self.definition, 'range error' + errstr))
@@ -184,14 +184,14 @@ class BooleanTypeSpec(TypeSpec):
     def __init__(self):
         TypeSpec.__init__(self, 'boolean')
 
-    def str_to_val(self, errors, pos, str):
-        if str == 'true':
+    def str_to_val(self, errors, pos, string):
+        if string == 'true':
             return True
-        elif str == 'false':
+        elif string == 'false':
             return False
         else:
             err_add(errors, pos, 'TYPE_VALUE',
-                    (str, self.definition, 'not a boolean'))
+                    (string, self.definition, 'not a boolean'))
             return None
 
 class StringTypeSpec(TypeSpec):
@@ -205,12 +205,12 @@ class BinaryTypeSpec(TypeSpec):
     def __init__(self):
         TypeSpec.__init__(self, 'binary')
 
-    def str_to_val(self, errors, pos, s):
+    def str_to_val(self, errors, pos, string):
         try:
-            return base64.b64decode(s)
+            return base64.b64decode(string)
         except:
             err_add(errors, pos, 'TYPE_VALUE',
-                    (s, '', 'bad base64 value'))
+                    (string, '', 'bad base64 value'))
 
     def restrictions(self):
         return ['length']
@@ -219,7 +219,7 @@ class EmptyTypeSpec(TypeSpec):
     def __init__(self):
         TypeSpec.__init__(self, 'empty')
 
-    def str_to_val(self, errors, pos, str):
+    def str_to_val(self, errors, pos, string):
         err_add(errors, pos, 'BAD_DEFAULT_VALUE', 'empty')
         return None
 
@@ -228,12 +228,8 @@ class IdentityrefTypeSpec(TypeSpec):
         TypeSpec.__init__(self, 'identityref')
         self.idbases = idbases
 
-    def str_to_val(self, errors, pos, s):
-        if s.find(":") == -1:
-            prefix = None
-            name = s
-        else:
-            [prefix, name] = s.split(':', 1)
+    def str_to_val(self, errors, pos, string):
+        prefix, name = util.split_identifier(string)
         if prefix is None or self.idbases[0].i_module.i_prefix == prefix:
             # check local identities
             pmodule = self.idbases[0].i_module
@@ -245,16 +241,15 @@ class IdentityrefTypeSpec(TypeSpec):
                 return None
         if name not in pmodule.i_identities:
             err_add(errors, pos, 'TYPE_VALUE',
-                    (s, self.definition, 'identityref not found'))
+                    (string, self.definition, 'identityref not found'))
             return None
         val = pmodule.i_identities[name]
         for idbase in self.idbases:
             my_identity = idbase.i_identity
             if not is_derived_from(val, my_identity):
                 err_add(errors, pos, 'TYPE_VALUE',
-                        (s, self.definition,
-                         'identityref not derived from %s' % \
-                         my_identity.arg))
+                        (string, self.definition,
+                         'identityref not derived from %s' % my_identity.arg))
                 return None
         return val
 
@@ -285,18 +280,18 @@ def validate_range_expr(errors, stmt, type_):
     is_int = hasattr(type_.i_type_spec, 'is_int')
 
     # break the expression apart
-    def convert(str_):
-        if not str_:
+    def convert(string):
+        if not string:
             # this means that a single number was in the range, e.g.
             # "4 | 5..6" - the high value match group is empty.
             val = None
-        elif str_ in ('min', 'max'):
-            val = str_
+        elif string in ('min', 'max'):
+            val = string
         else:
-            if is_int and syntax.re_integer.search(str_) is None:
+            if is_int and syntax.re_integer.search(string) is None:
                 err_add(errors, stmt.pos, 'TYPE_VALUE',
-                        (str_, type_.i_type_spec.definition, 'not an integer'))
-            val = type_.i_type_spec.str_to_val(errors, stmt.pos, str_)
+                        (string, type_.i_type_spec.definition, 'not an integer'))
+            val = type_.i_type_spec.str_to_val(errors, stmt.pos, string)
         return val
 
     ranges = [(convert(m[1]), convert(m[6]))
@@ -306,10 +301,10 @@ def validate_range_expr(errors, stmt, type_):
 def validate_ranges(errors, pos, ranges, type_):
     # make sure the range values are of correct type and increasing
     cur_lo = None
-    for (lo, hi) in ranges:
-        if lo != 'min' and lo != 'max' and lo != None:
+    for lo, hi in ranges:
+        if lo != 'min' and lo != 'max' and lo is not None:
             type_.i_type_spec.validate(errors, pos, lo)
-        if hi != 'min' and hi != 'max' and hi != None:
+        if hi != 'min' and hi != 'max' and hi is not None:
             type_.i_type_spec.validate(errors, pos, hi)
         # check that cur_lo < lo < hi
         if not is_smaller(cur_lo, lo):
@@ -318,7 +313,7 @@ def validate_ranges(errors, pos, ranges, type_):
         if not is_smaller(lo, hi):
             err_add(errors, pos, 'RANGE_BOUNDS', (str(hi), str(lo)))
             return None
-        if hi == None:
+        if hi is None:
             cur_lo = lo
         else:
             cur_lo = hi
@@ -331,12 +326,12 @@ class RangeTypeSpec(TypeSpec):
         (ranges, ranges_pos) = range_spec
         self.ranges = ranges
         self.ranges_pos = ranges_pos
-        if ranges != []:
+        if ranges:
             self.min = ranges[0][0]
             if self.min == 'min':
                 self.min = base.min
             self.max = ranges[-1][1]
-            if self.max == None: # single range
+            if self.max is None: # single range
                 self.max = ranges[-1][0]
             if self.max == 'max':
                 self.max = base.max
@@ -346,13 +341,13 @@ class RangeTypeSpec(TypeSpec):
         if hasattr(base, 'fraction_digits'):
             self.fraction_digits = base.fraction_digits
 
-    def str_to_val(self, errors, pos, str):
-        return self.base.str_to_val(errors, pos, str)
+    def str_to_val(self, errors, pos, string):
+        return self.base.str_to_val(errors, pos, string)
 
     def validate(self, errors, pos, val, errstr=''):
-        if self.base.validate(errors, pos, val, errstr) == False:
+        if self.base.validate(errors, pos, val, errstr) is False:
             return False
-        for (lo, hi) in self.ranges:
+        for lo, hi in self.ranges:
             if ((lo == 'min' or lo == 'max' or val >= lo) and
                 ((hi is None and val == lo) or hi == 'max' or \
                      (hi is not None and val <= hi))):
@@ -390,10 +385,11 @@ def validate_length_expr(errors, stmt):
                     (histr, '', 'not an integer'))
             return None
         return (lo, hi)
+
     lengths = [f(m[1], m[3]) for m in syntax.re_length_part.findall(stmt.arg)]
     # make sure the length values are of correct type and increasing
     cur_lo = None
-    for (lo, hi) in lengths:
+    for lo, hi in lengths:
         # check that cur_lo < lo < hi
         if not is_smaller(cur_lo, lo):
             err_add(errors, stmt.pos, 'LENGTH_BOUNDS', (str(lo), cur_lo))
@@ -406,7 +402,7 @@ def validate_length_expr(errors, stmt):
         # that... currently we can't check just length values; we'd have
         # to pass just the length integer to typespec.validate().  Or
         # something...
-        if hi == None:
+        if hi is None:
             cur_lo = lo
         else:
             cur_lo = hi
@@ -423,14 +419,14 @@ class LengthTypeSpec(TypeSpec):
         self.lengths = lengths
         self.length_pos = length_pos
 
-    def str_to_val(self, errors, pos, str):
-        return self.base.str_to_val(errors, pos, str)
+    def str_to_val(self, errors, pos, string):
+        return self.base.str_to_val(errors, pos, string)
 
     def validate(self, errors, pos, val, errstr=''):
-        if self.base.validate(errors, pos, val, errstr) == False:
+        if self.base.validate(errors, pos, val, errstr) is False:
             return False
         vallen = len(val)
-        for (lo, hi) in self.lengths:
+        for lo, hi in self.lengths:
             if ((lo == 'min' or vallen >= lo) and
                 ((hi is None and vallen == lo) or hi == 'max' or
                  (hi is not None and vallen <= hi))):
@@ -504,13 +500,13 @@ class PatternTypeSpec(TypeSpec):
         self.base = base
         self.res = pattern_specs
 
-    def str_to_val(self, errors, pos, str):
-        return self.base.str_to_val(errors, pos, str)
+    def str_to_val(self, errors, pos, string):
+        return self.base.str_to_val(errors, pos, string)
 
     def validate(self, errors, pos, val, errstr=''):
-        if self.base.validate(errors, pos, val, errstr) == False:
+        if self.base.validate(errors, pos, val, errstr) is False:
             return False
-        for (type_, re, re_pos, invert_match, patstr) in self.res:
+        for type_, re, re_pos, invert_match, patstr in self.res:
             if type_ == 'libxml2':
                 is_valid = re.regexpExec(val) == 1
             elif type_ == 'lxml':
@@ -534,7 +530,7 @@ def validate_enums(errors, enums, stmt):
     # make sure all names and values given are unique
     names = {}
     values = {}
-    next = 0
+    auto = 0
     for e in enums:
         # for derived enumerations, make sure the enum is defined
         # in the base
@@ -552,8 +548,8 @@ def validate_enums(errors, enums, stmt):
                 e.i_value = x
                 if x < -2147483648 or x > 2147483647:
                     raise ValueError
-                if x >= next:
-                    next = x + 1
+                if x >= auto:
+                    auto = x + 1
                 if x in values:
                     err_add(errors, value.pos, 'DUPLICATE_ENUM_VALUE',
                             (x, values[x]))
@@ -564,11 +560,11 @@ def validate_enums(errors, enums, stmt):
                 err_add(errors, value.pos, 'ENUM_VALUE', value.arg)
         else:
             # auto-assign a value
-            values[next] = e.pos
-            if next > 2147483647:
-                err_add(errors, e.pos, 'ENUM_VALUE', str(next))
-            e.i_value = next
-            next = next + 1
+            values[auto] = e.pos
+            if auto > 2147483647:
+                err_add(errors, e.pos, 'ENUM_VALUE', str(auto))
+            e.i_value = auto
+            auto = auto + 1
         if e.arg in names:
             err_add(errors, e.pos, 'DUPLICATE_ENUM_NAME', (e.arg, names[e.arg]))
         else:
@@ -593,8 +589,8 @@ class EnumTypeSpec(TypeSpec):
         self.base = base
         self.enums = [(e.arg, e.i_value) for e in enums]
 
-    def validate(self, errors, pos, val, errstr = ''):
-        if util.keysearch(val, 0, self.enums) == None:
+    def validate(self, errors, pos, val, errstr=''):
+        if util.keysearch(val, 0, self.enums) is None:
             err_add(errors, pos, 'TYPE_VALUE',
                     (val, self.definition, 'enum not defined' + errstr))
             return False
@@ -615,7 +611,7 @@ def validate_bits(errors, bits, stmt):
     # make sure all names and positions given are unique
     names = {}
     values = {}
-    next = 0
+    auto = 0
     for b in bits:
         # for derived bits, make sure the bit is defined
         # in the base
@@ -632,8 +628,8 @@ def validate_bits(errors, bits, stmt):
                 b.i_position = x
                 if x < 0 or x > 4294967295:
                     raise ValueError
-                if x >= next:
-                    next = x + 1
+                if x >= auto:
+                    auto = x + 1
                 if x in values:
                     err_add(errors, position.pos, 'DUPLICATE_BIT_POSITION',
                             (x, values[x]))
@@ -643,11 +639,11 @@ def validate_bits(errors, bits, stmt):
                 err_add(errors, position.pos, 'BIT_POSITION', position.arg)
         else:
             # auto-assign a value
-            if next > 4294967295:
-                err_add(errors, b.pos, 'BIT_POSITION', str(next))
-            values[next] = b.pos
-            b.i_position = next
-            next = next + 1
+            if auto > 4294967295:
+                err_add(errors, b.pos, 'BIT_POSITION', str(auto))
+            values[auto] = b.pos
+            b.i_position = auto
+            auto = auto + 1
         if b.arg in names:
             err_add(errors, b.pos, 'DUPLICATE_BIT_NAME', (b.arg, names[b.arg]))
         else:
@@ -672,12 +668,12 @@ class BitTypeSpec(TypeSpec):
         self.base = base
         self.bits = [(b.arg, b.i_position) for b in bits]
 
-    def str_to_val(self, errors, pos, str):
-        return str.split()
+    def str_to_val(self, errors, pos, string):
+        return string.split()
 
-    def validate(self, errors, pos, val, errstr = ''):
+    def validate(self, errors, pos, val, errstr=''):
         for v in val:
-            if util.keysearch(v, 0, self.bits) == None:
+            if util.keysearch(v, 0, self.bits) is None:
                 err_add(errors, pos, 'TYPE_VALUE',
                         (v, self.definition, 'bit not defined' + errstr))
                 return False
@@ -853,15 +849,15 @@ class PathTypeSpec(TypeSpec):
         self.path_ = path
         self.pos = pos
 
-    def str_to_val(self, errors, pos, str_):
+    def str_to_val(self, errors, pos, string):
         if hasattr(self, 'i_target_node'):
             return self.i_target_node.search_one('type').\
-                i_type_spec.str_to_val(errors, pos, str_)
+                i_type_spec.str_to_val(errors, pos, string)
         else:
             # if a default value is verified
-            return str_
+            return string
 
-    def validate(self, errors, pos, val, errstr = ''):
+    def validate(self, errors, pos, val, errstr=''):
         if hasattr(self, 'i_target_node'):
             return self.i_target_node.search_one('type').\
                 i_type_spec.validate(errors, pos, val)
@@ -878,56 +874,56 @@ class UnionTypeSpec(TypeSpec):
         # no base - no restrictions allowed
         self.types = types
 
-    def str_to_val(self, errors, pos, str):
-        return str
+    def str_to_val(self, errors, pos, string):
+        return string
 
-    def validate(self, errors, pos, str, errstr = ''):
+    def validate(self, errors, pos, val, errstr=''):
         # try to validate against each membertype
         for t in self.types:
-            if t.i_type_spec != None:
-                val = t.i_type_spec.str_to_val([], pos, str)
-                if val != None:
-                    if t.i_type_spec.validate([], pos, val):
+            if t.i_type_spec is not None:
+                t_val = t.i_type_spec.str_to_val([], pos, val)
+                if t_val is not None:
+                    if t.i_type_spec.validate([], pos, t_val):
                         return True
         err_add(errors, pos, 'TYPE_VALUE',
-                (str, self.definition, 'no member type matched' + errstr))
+                (val, self.definition, 'no member type matched' + errstr))
         return False
 
-yang_type_specs = \
-  {'int8':IntTypeSpec('int8', -128, 127),
-   'int16':IntTypeSpec('int16', -32768, 32767),
-   'int32':IntTypeSpec('int32', -2147483648, 2147483647),
-   'int64':IntTypeSpec('int64', -9223372036854775808, 9223372036854775807),
-   'uint8':IntTypeSpec('uint8', 0, 255),
-   'uint16':IntTypeSpec('uint16', 0, 65535),
-   'uint32':IntTypeSpec('uint32', 0, 4294967295),
-   'uint64':IntTypeSpec('uint64', 0, 18446744073709551615),
-   'decimal64':TypeSpec('decimal64'),
-   'string':StringTypeSpec(),
-   'boolean':BooleanTypeSpec(),
-   'enumeration':EnumerationTypeSpec(),
-   'bits':BitsTypeSpec(),
-   'binary':BinaryTypeSpec(),
-   'leafref':LeafrefTypeSpec(),
-   'identityref':TypeSpec('identityref'),
-   'instance-identifier':InstanceIdentifierTypeSpec(),
-   'empty':EmptyTypeSpec(),
-   'union':TypeSpec('union'),
+yang_type_specs = {
+   'int8': IntTypeSpec('int8', -128, 127),
+   'int16': IntTypeSpec('int16', -32768, 32767),
+   'int32': IntTypeSpec('int32', -2147483648, 2147483647),
+   'int64': IntTypeSpec('int64', -9223372036854775808, 9223372036854775807),
+   'uint8': IntTypeSpec('uint8', 0, 255),
+   'uint16': IntTypeSpec('uint16', 0, 65535),
+   'uint32': IntTypeSpec('uint32', 0, 4294967295),
+   'uint64': IntTypeSpec('uint64', 0, 18446744073709551615),
+   'decimal64': TypeSpec('decimal64'),
+   'string': StringTypeSpec(),
+   'boolean': BooleanTypeSpec(),
+   'enumeration': EnumerationTypeSpec(),
+   'bits': BitsTypeSpec(),
+   'binary': BinaryTypeSpec(),
+   'leafref': LeafrefTypeSpec(),
+   'identityref': TypeSpec('identityref'),
+   'instance-identifier': InstanceIdentifierTypeSpec(),
+   'empty': EmptyTypeSpec(),
+   'union': TypeSpec('union'),
    }
 
 def is_base_type(typename):
     return typename in yang_type_specs
 
 def is_smaller(lo, hi):
-    if lo == None:
+    if lo is None:
         return True
     if lo == 'min' and hi != 'min':
         return True
-    if lo == 'max' and hi != None:
+    if lo == 'max' and hi is not None:
         return False
     if hi == 'min':
         return False
-    if hi == None:
+    if hi is None:
         return True
     if hi == 'max':
         return True

--- a/pyang/xpath_lexer.py
+++ b/pyang/xpath_lexer.py
@@ -118,7 +118,7 @@ def scan(s):
     toks = []
     while pos < len(s):
         matched = False
-        for (tokname, r) in patterns:
+        for tokname, r in patterns:
             m = r.match(s, pos)
             if m is not None:
                 # found a matching token
@@ -169,7 +169,7 @@ def scan(s):
                 toks.append(tok)
                 matched = True
                 break
-        if matched == False:
+        if not matched:
             # no patterns matched
             raise XPathError('syntax error', line, linepos)
     return toks

--- a/pyang/yang_parser.py
+++ b/pyang/yang_parser.py
@@ -86,7 +86,7 @@ class YangTokenizer(object):
         self.skip(keep_comments=True)
         offset = self.offset
         m = syntax.re_comment.match(self.buf)
-        if m == None:
+        if m is None:
             return None
         else:
             cmt = m.group(0)
@@ -113,7 +113,7 @@ class YangTokenizer(object):
         self.skip()
 
         m = syntax.re_keyword.match(self.buf)
-        if m == None:
+        if m is None:
             error.err_add(self.errors, self.pos,
                           'SYNTAX_ERROR', 'illegal keyword: ' + self.buf)
             raise error.Abort
@@ -130,7 +130,7 @@ class YangTokenizer(object):
                               self.buf[:6] + '..."')
                 raise error.Abort
 
-            if m.group(2) == None: # no prefix
+            if m.group(2) is None: # no prefix
                 return m.group(3)
             else:
                 return (m.group(2), m.group(3))
@@ -208,7 +208,7 @@ class YangTokenizer(object):
                         elif self.strict_quoting:
                             error.err_add(self.errors, self.pos,
                                           'ILLEGAL_ESCAPE_WARN', self.buf[i+1])
-                        if special != None:
+                        if special is not None:
                             res.append(self.buf[start:i])
                             res.append(special)
                             i = i + 1
@@ -247,7 +247,7 @@ class YangTokenizer(object):
                     elif i == buflen:
                         # whitespace only on this line; keep it as is
                         i = 0
-        elif need_quote == True:
+        elif need_quote is True:
             error.err_add(self.errors, self.pos, 'EXPECTED_QUOTED_STRING', ())
             raise error.Abort
         else:
@@ -303,7 +303,7 @@ class YangParser(object):
         # treat it differently than we treat keywords further down
         if self.ctx.keep_comments:
             cmt = self.tokenizer.get_comment()
-            if cmt != None:
+            if cmt is not None:
                 stmt = statements.new_statement(self.top,
                                                 parent,
                                                 self.pos,
@@ -360,7 +360,7 @@ def pp(s, indent=0):
     sys.stdout.write(" " * indent + ppkeywd(s.raw_keyword))
     if s.arg is not None:
         sys.stdout.write(" '" + s.arg + "'")
-    if s.substmts == []:
+    if not s.substmts:
         sys.stdout.write(";\n")
     else:
         sys.stdout.write(" {\n")

--- a/pyang/yin_parser.py
+++ b/pyang/yin_parser.py
@@ -112,7 +112,7 @@ class YinParser(object):
             error.err_add(self.ctx.errors, self.pos, 'SYNTAX_ERROR',
                           "unexpected element - mixed content")
         self.data = ''
-        if self.element_stack == []:
+        if not self.element_stack:
             # this is the top-level element
             self.top_element = e
             self.element_stack.append(e)
@@ -177,7 +177,7 @@ class YinParser(object):
             (arg_is_elem, argname)  = res
 
         keywdstr = util.keyword_to_str(keywd)
-        if arg_is_elem == True:
+        if arg_is_elem is True:
             # find the argument element
             arg_elem = e.find_child(e.ns, argname)
             if arg_elem is None:
@@ -192,7 +192,7 @@ class YinParser(object):
                 else:
                     arg = arg_elem.data
                 e.remove_child(arg_elem)
-        elif arg_is_elem == False:
+        elif arg_is_elem is False:
             arg = e.find_attribute(argname)
             if arg is None:
                 error.err_add(self.ctx.errors, e.pos,

--- a/test/plugins/yangxml.py
+++ b/test/plugins/yangxml.py
@@ -30,12 +30,12 @@ def emit_xml(module, fd):
     emit_stmt(c, fd, '', attrs, 1)
 
 def emit_stmt(stmt, fd, ind, attrs='', n=None):
-    if n == None and stmt.keyword in ['list', 'leaf-list']:
+    if n is None and stmt.keyword in ['list', 'leaf-list']:
         lb = 0
-        if stmt.search_one('min_elements') != None:
+        if stmt.search_one('min_elements') is not None:
             lb = int(stmt.search_one('min_elements').arg)
         ub = 3 # 3 is many
-        if (stmt.search_one('max_elements') != None and
+        if (stmt.search_one('max_elements') is not None and
             stmt.search_one('max_elements').arg != 'unbounded'):
             ub = int(stmt.search_one('max_elements').arg)
             if ub > 3:
@@ -63,37 +63,37 @@ def emit_stmt(stmt, fd, ind, attrs='', n=None):
 
 def emit_leaf(stmt, fd, ind, attrs):
     do_print = True
-    if ((stmt.search_one('mandatory') != None) and
+    if ((stmt.search_one('mandatory') is not None) and
         (stmt.search_one('mandatory').arg == 'false') or
-        (stmt.search_one('default') != None) or
-        (statements.has_type(stmt.search_one('type'), ['empty']) != None)):
+        (stmt.search_one('default') is not None) or
+        (statements.has_type(stmt.search_one('type'), ['empty']) is not None)):
         if random() < 0.3:
             do_print = False
-    if do_print == True:
+    if do_print:
         fd.write(ind + '<%s%s>' % (stmt.arg, attrs))
         emit_type_val(stmt.search_one('type'), fd)
         fd.write('</%s>\n' % stmt.arg)
 
 def emit_container(stmt, fd, ind, attrs):
     do_print = True
-    if stmt.search_one('presence') != None:
+    if stmt.search_one('presence') is not None:
         if random() < 0.3:
             do_print = False
-    if do_print == True:
+    if do_print:
         fd.write(ind + '<%s%s>\n' % (stmt.arg, attrs))
         for c in stmt.i_children:
             emit_stmt(c, fd, ind + '  ')
         fd.write(ind + '</%s>\n' % stmt.arg)
 
 def emit_leaf_list(stmt, n, fd, ind, attrs):
-    while (n > 0):
+    while n > 0:
         fd.write(ind + '<%s%s>' % (stmt.arg, attrs))
         emit_type_val(stmt.search_one('type'), fd)
         fd.write('</%s>\n' % stmt.arg)
         n = n - 1
 
 def emit_list(stmt, n, fd, ind, attrs):
-    while (n > 0):
+    while n > 0:
         fd.write(ind + '<%s%s>\n' % (stmt.arg, attrs))
         cs = stmt.i_children
         for k in stmt.i_key:
@@ -110,47 +110,47 @@ def emit_anyxml(stmt, fd, ind):
     fd.write(ind + '<%s><bar xmlns="">42</bar></%s>\n' % (stmt.arg, stmt.arg))
 
 def emit_type_val(t, fd):
-    if t.i_is_derived == False and t.i_typedef != None:
+    if t.i_is_derived is False and t.i_typedef is not None:
         return emit_type_val(t.i_typedef.search_one('type'), fd)
     inttype = statements.has_type(t, ['int8','int16','int32','int64',
                                       'uint8','uint16','uint32','uint64'])
     enum = t.search('enum')
-    range = t.search_one('range')
-    if enum != []:
+    trange = t.search_one('range')
+    if enum:
         enum = pick(enum)
         fd.write(enum.arg)
-    elif statements.has_type(t, ['empty']) != None:
+    elif statements.has_type(t, ['empty']) is not None:
         pass
-    elif range != None:
+    elif trange is not None:
         (lo,hi) = pick(t.i_ranges)
         ts = types.yang_type_specs[inttype.arg]
         if lo == 'min':
             lo = ts.min
         if hi == 'max':
             hi = ts.max
-        if hi == None:
+        if hi is None:
             hi = lo
         val = randint(lo,hi)
         fd.write(str(val))
-    elif statements.has_type(t, ['boolean']) != None:
+    elif statements.has_type(t, ['boolean']) is not None:
         val = pick(['true','false'])
         fd.write(val)
-    elif inttype != None:
+    elif inttype is not None:
         ts = types.yang_type_specs[inttype.arg]
         val = randint(ts.min, ts.max)
         fd.write(str(val))
-    elif statements.has_type(t, ['ipv4-address']) != None:
+    elif statements.has_type(t, ['ipv4-address']) is not None:
         fd.write('10.0.0.1')
     else:
         length = t.search_one('length')
         pattern = t.search('pattern')
-        if length != None:
+        if length is not None:
             # pick a length
             (lo,hi) = pick(t.i_lengths)
-            if hi == None:
+            if hi is None:
                 hi = lo
             lentgh = randint(lo,hi)
-        if pattern != []:
+        if pattern:
             # oh boy
             pass
         fd.write('__foo__')


### PR DESCRIPTION
Avoid reusing builtin function names; file is not builtin in python3.
Unify arguments lists for str_to_val, validate in types.
Remove unused listsdelete from util, _peek_revision from pyang.
Improve implementation of some utils; add split_prefix util.
Avoid singleton comparisons for None, True, False.
Prefer startswith / in conditions to str.find comparisons.
Prefer getattr to hasattr where less verbose.
Use empty/nonempty lists as bools instead of comparing with empty.
Prefer formatted strings to concatenation; avoid str(x) due to python2.
Remove most unneeded parentheses from if/loop/return/multi-assignments.
Some whitespace/line formatting improvements.