### PR TITLE
Add pylint run; new approach to coverage

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+ignore-patterns = .*yacc
+extension-pkg-whitelist = lxml.etree
+
+[SIMILARITIES]
+ignore-imports = yes
+
+[MESSAGES-CONTROL]
+disable =
+    invalid-name,
+    missing-docstring

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   # - "3.5" # error: coverage doesn't work
   - "3.6"
   - "3.7"
+  - "3.8"
 addons:
   apt:
     packages:
@@ -18,17 +19,12 @@ addons:
 install:
   - pip install -r requirements.txt
   - pip install -r dev-requirements.txt
-  - SITEPACKAGES=$(pip --version | sed -n 's@.*from \([^ ]\+\) .*@\1@p')
-  - echo 'import coverage; coverage.process_startup()' > $SITEPACKAGES/sitecustomize.py
-  - printf '[run]\nparallel=True\n' > ~/coverage.cfg
 script:
   - source env.sh
-  - export COVERAGE_PROCESS_START=~/coverage.cfg
   - export USE_VIRTUALENV=true
   - make test
   - find . -name '.coverage*' -exec mv -t . {} +
-  # tmp ignore no coverage files
-  - coverage combine || true
+  - coverage combine
   # Test .gitignore for tests:
   - TMP=$(tempfile)
   - git ls-files . --exclude-standard --others | tee "$TMP"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export W := $(shell pwd)
+
 # create a full source package
 sdist: build
 	python setup.py sdist
@@ -21,6 +23,9 @@ test: lint
 
 lint:
 	flake8 .
+	touch bin/__init__.py  # makes pylint tell pyang script apart from pyang package
+	pylint bin/pyang bin/json2xml bin/yang2html pyang $(shell find test -name '*.py') || true
+	rm -f bin/__init__.py
 
 clean:
 	rm -f pyang/parser.out pyang/xpath_parsetab.py
@@ -29,6 +34,7 @@ clean:
 	python setup.py clean --all
 	rm -rf build dist MANIFEST
 	find . -name "*.pyc" -exec rm {} \;
+	find . -name "__pycache__" -exec rm -rf {} \;
 
 tags:
 	find . -name "*.py" | etags -

--- a/bin/yang2dsdl
+++ b/bin/yang2dsdl
@@ -251,7 +251,7 @@ if [ "$noschema" = "0" ] ; then
         pyang_opts="${pyang_opts} --hello"
         printf "\n"
     fi
-    pyang -f dsdl -o $hybs $pyang_opts $infiles
+    ${PYANG:-pyang} -f dsdl -o $hybs $pyang_opts $infiles
     [ $? -eq 0 ] || exit 2
     if [ "$basename" = "" ] ; then
         basename=$(xsltproc $xslt_dir/basename.xsl $hybs)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ virtualenv
 pycodestyle
 pyflakes
 flake8
+pylint

--- a/env.sh
+++ b/env.sh
@@ -3,11 +3,10 @@
 # source this file to get environment setup for the
 # pyang below here
 
-p=`pwd`
-export PATH="$p/bin:$PATH"
-export MANPATH="$p/man:$MANPATH"
-export PYTHONPATH="$p:$PYTHONPATH"
-export YANG_MODPATH="$p/modules:$YANG_MODPATH"
-export PYANG_XSLT_DIR="$p/xslt"
-export PYANG_RNG_LIBDIR="$p/schema"
-export W="$p"
+export PATH="$PWD/bin:$PATH"
+export MANPATH="$PWD/man:$MANPATH"
+export PYTHONPATH="$PWD:$PYTHONPATH"
+export YANG_MODPATH="$PWD/modules:$YANG_MODPATH"
+export PYANG_XSLT_DIR="$PWD/xslt"
+export PYANG_RNG_LIBDIR="$PWD/schema"
+export W="$PWD"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,10 @@
 DIRS = $(shell for d in test_* ; \
 	do [ -d $$d -a -f $$d/Makefile ] && echo $$d ; done)
+COVERAGE := python -mcoverage run --branch --parallel-mode --source $(W)/pyang,$(W)/bin --omit $(W)/pyang/yacc.py
+export PYANG := $(COVERAGE) $(W)/bin/pyang
+export JSON2XML := $(COVERAGE) $(W)/bin/json2xml
+export YANG2HTML := $(COVERAGE) $(W)/bin/yang2html
+export YANG2DSDL := env PYANG='$(PYANG)' $(W)/bin/yang2dsdl
 
 test:
 	$(MAKE) itest
@@ -28,7 +33,7 @@ selftest:
 		( cd $$d;						\
 		for m in *.yang; do					\
 			echo "  $${m}... " | tr -d '\012';		\
-			pyang -Werror $$m || exit 1;			\
+			$(PYANG) -Werror $$m || exit 1;			\
 			echo "ok";					\
 		done ) || exit 1;					\
 	done || exit 1;
@@ -46,7 +51,8 @@ python3:
 	mkdir $@
 
 clean:
-	@for d in $(DIRS); do 						\
+	@find -name '.coverage*' -delete;				\
+	for d in $(DIRS); do 						\
 		  (cd $$d && $(MAKE) $@)				\
 	done;								\
 	rm -rf python2 python3

--- a/test/test_bad/Makefile
+++ b/test/test_bad/Makefile
@@ -1,7 +1,7 @@
 DIRS = $(shell for d in test_* ; \
 	do [ -d $$d -a -f $$d/Makefile ] && echo $$d ; done)
 
-PYANG = pyang --print-error-code --strict
+PYANG := $(PYANG) --print-error-code --strict
 
 MODULES = $(wildcard *.yang)
 

--- a/test/test_bad/test_date/Makefile
+++ b/test/test_bad/test_date/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang test.yang --print-error-code 2>&1 | grep BAD_VALUE
+	$(PYANG) test.yang --print-error-code 2>&1 | grep BAD_VALUE

--- a/test/test_bad/test_i190/Makefile
+++ b/test/test_bad/test_i190/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang tst-m.yang --lint --print-error-code 2>&1 | \
+	$(PYANG) tst-m.yang --lint --print-error-code 2>&1 | \
 	grep LINT_TOP_MANDATORY

--- a/test/test_bad/test_i201/Makefile
+++ b/test/test_bad/test_i201/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang tst-m.yang --lint --print-error-code 2>&1 | grep LINT_BAD_REVISION
+	$(PYANG) tst-m.yang --lint --print-error-code 2>&1 | grep LINT_BAD_REVISION

--- a/test/test_bad/test_i206/Makefile
+++ b/test/test_bad/test_i206/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang test.yang --print-error-code 2>&1 | grep NODE_NOT_FOUND
+	$(PYANG) test.yang --print-error-code 2>&1 | grep NODE_NOT_FOUND

--- a/test/test_canonical/Makefile
+++ b/test/test_canonical/Makefile
@@ -1,4 +1,4 @@
-PYANG = pyang -Wnone
+PYANG := $(PYANG) -Wnone
 
 MODULES = $(wildcard *.yang)
 

--- a/test/test_dsdl/Makefile
+++ b/test/test_dsdl/Makefile
@@ -1,6 +1,6 @@
 PYANG_RNG_LIBDIR = ../../schema
 PYANG_XSLT_DIR = ../../xslt
-YANG2DSDL := ../../bin/yang2dsdl
+YANG2DSDL ?= ../../bin/yang2dsdl
 
 results := $(patsubst %.xml,%.log,$(wildcard *.xml))
 

--- a/test/test_good/Makefile
+++ b/test/test_good/Makefile
@@ -1,39 +1,40 @@
-PYANG = pyang -Werror -WWBAD_MODULE_NAME
+PYANGE := $(PYANG) -Werror -WWBAD_MODULE_NAME
 
 test: clean utf8-test mef-ieee-test
 	@for m in $(wildcard *.yang); do 				\
 		echo "checking $$m..." | tr -d '\012';			\
-		$(PYANG) $$m || exit 1;					\
+		$(PYANGE) $$m || exit 1;				\
 		echo " generating yin...";				\
-		$(PYANG) -f yin -o $$m.yin $$m || exit 1;		\
+		$(PYANGE) -f yin -o $$m.yin $$m || exit 1;		\
 		echo " " | tr -d '\012';				\
 		echo " generating yang from the generated yin...";	\
-		$(PYANG) -f yang -o $$m.gen.yang $$m.yin || exit 1;	\
+		$(PYANGE) -f yang -o $$m.gen.yang $$m.yin || exit 1;	\
 		echo " " | tr -d '\012';				\
 		echo " generating yang..." | tr -d '\012';		\
-		$(PYANG) -f yang -o $$m.gen.yang $$m || exit 1;		\
+		$(PYANGE) -f yang -o $$m.gen.yang $$m || exit 1;	\
 		echo " generating yin from the generated yang...";	\
-		$(PYANG) -f yin -o $$m.gen.yin $$m.gen.yang || exit 1;	\
+		$(PYANGE) -f yin -o $$m.gen.yin $$m.gen.yang || exit 1;	\
 		echo " " | tr -d '\012';				\
 		echo " comparing the two generated yin..." | tr -d '\012';\
 		diff $$m.yin $$m.gen.yin > $$m.diff ||	 		\
 			{ cat $$m.diff; exit 1; };			\
 		rm -f $$m.diff;						\
 		echo " generating DSDL..." | tr -d '\012';		\
-		(grep '^submodule' $$m > /dev/null || $(PYANG) -f dsdl -o $$m.dsdl $$m || exit 0);	\
+		(grep '^submodule' $$m > /dev/null			\
+                || $(PYANGE) -f dsdl -o $$m.dsdl $$m || exit 0);	\
 		echo " ok";						\
 	done
 
 utf8-test:
-	pyang -f yang q.yang || exit 1; \
-	pyang -f yang q.yang > x || exit 1; \
-	pyang -f yang q.yang -o x || exit 1; \
+	$(PYANG) -f yang q.yang || exit 1; \
+	$(PYANG) -f yang q.yang > x || exit 1; \
+	$(PYANG) -f yang q.yang -o x || exit 1; \
 	rm -f x
 
 mef-ieee-test:
-	pyang --mef mef-yt10.yang || exit 1; \
-        pyang --mef mef-yt11.yang || exit 1; \
-        pyang --ieee ieee-yt12.yang || exit 1;
+	$(PYANG) --mef mef-yt10.yang || exit 1; \
+        $(PYANG) --mef mef-yt11.yang || exit 1; \
+        $(PYANG) --ieee ieee-yt12.yang || exit 1;
 
 clean:
 	rm -rf *.yang.yin *.gen.* *.dsdl

--- a/test/test_good/Makefile.DSDL
+++ b/test/test_good/Makefile.DSDL
@@ -4,7 +4,7 @@ test: clean
 	@for m in $(MODULES); do 					\
 	  for t in $(TARGETS); do 					\
 		echo "checking $$m - $$t";				\
-		yang2dsdl -t $$t $$m;					\
+		$(YANG2DSDL) -t $$t $$m;				\
 	  done;								\
 	done
 

--- a/test/test_hello/Makefile
+++ b/test/test_hello/Makefile
@@ -11,17 +11,17 @@ Y2DOPTS = -L -t $(TARGET) -b $(BASE)
 all: $(SCHEMAS)
 
 $(SCHEMAS): $(HELLO) $(MODULES)
-	yang2dsdl $(Y2DOPTS) $(FULLEXT) $<
+	$(YANG2DSDL) $(Y2DOPTS) $(FULLEXT) $<
 
 clean:
 	rm -f $(SCHEMAS) $BASE.{dsdl,tree} *-gdefs.rng *.rnc
 
 test: $(INSTANCE) $(SCHEMAS)
-	yang2dsdl -j -s $(Y2DOPTS) -v $<
+	$(YANG2DSDL) -j -s $(Y2DOPTS) -v $<
 
 $(BASE).dsdl: $(HELLO) $(MODULES)
-	pyang -f dsdl --dsdl-no-documentation $(FULLEXT) $< \
+	$(PYANG) -f dsdl --dsdl-no-documentation $(FULLEXT) $< \
 	| xmllint --format - > $@
 
 $(BASE).tree: $(HELLO) $(MODULES)
-	pyang -f tree -o $@ $(FULLEXT) $<
+	$(PYANG) -f tree -o $@ $(FULLEXT) $<

--- a/test/test_issues/test_i126/Makefile
+++ b/test/test_issues/test_i126/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang -Werror -L hello.xml
+	$(PYANG) -Werror -L hello.xml

--- a/test/test_issues/test_i183/Makefile
+++ b/test/test_issues/test_i183/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang --canonical --print-error-code 2>&1 | diff a.expect -
+	$(PYANG) a.yang --canonical --print-error-code 2>&1 | diff a.expect -

--- a/test/test_issues/test_i218/Makefile
+++ b/test/test_issues/test_i218/Makefile
@@ -1,7 +1,7 @@
 test: test1 test2
 
 test1:
-	pyang -f yin x.yang | pyang -f yang | diff x.yang -
+	$(PYANG) -f yin x.yang | $(PYANG) -f yang | diff x.yang -
 
 test2:
-	pyang -f tree x.yang | diff x.tree.expect -
+	$(PYANG) -f tree x.yang | diff x.tree.expect -

--- a/test/test_issues/test_i230/Makefile
+++ b/test/test_issues/test_i230/Makefile
@@ -1,9 +1,9 @@
 test:
-	PYANG_PLUGINPATH=. pyang -f yin example-sports.yang \
+	PYANG_PLUGINPATH=. $(PYANG) -f yin example-sports.yang \
 			 -o example-sports.yin
-	pyang -f tree --tree-path=sports/person/name example-sports.yang \
+	$(PYANG) -f tree --tree-path=sports/person/name example-sports.yang \
 		-o example-sports.tree
-	pyang -f omni --omni-path=sports/person/name example-sports.yang \
+	$(PYANG) -f omni --omni-path=sports/person/name example-sports.yang \
 		-o example-sports.omni
 	rm -f *.yin *.tree *.omni
 

--- a/test/test_issues/test_i262/Makefile
+++ b/test/test_issues/test_i262/Makefile
@@ -1,3 +1,3 @@
 # this used to crash
 test:
-	pyang -f jsonxsl example-4-a.yang example-4-b.yang > /dev/null
+	$(PYANG) -f jsonxsl example-4-a.yang example-4-b.yang > /dev/null

--- a/test/test_issues/test_i263/Makefile
+++ b/test/test_issues/test_i263/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang --deviation-module test-dev.yang test.yang > /dev/null
+	$(PYANG) --deviation-module test-dev.yang test.yang > /dev/null

--- a/test/test_issues/test_i267/Makefile
+++ b/test/test_issues/test_i267/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang --print-error-code test.yang --deviation-module=test-dev.yang \
+	$(PYANG) --print-error-code test.yang --deviation-module=test-dev.yang \
 	  2>&1 | grep BAD_DEVIATE_ADD > /dev/null

--- a/test/test_issues/test_i271/Makefile
+++ b/test/test_issues/test_i271/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang --lint my-x.yang > /dev/null
+	$(PYANG) --lint my-x.yang > /dev/null

--- a/test/test_issues/test_i275/Makefile
+++ b/test/test_issues/test_i275/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang --print-error-code x.yang 2>&1 | grep NODE_NOT_FOUND > /dev/null
+	$(PYANG) --print-error-code x.yang 2>&1 | grep NODE_NOT_FOUND > /dev/null

--- a/test/test_issues/test_i276/Makefile
+++ b/test/test_issues/test_i276/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang x.yang --print-error-code 2>&1 | diff x.expect -
+	$(PYANG) x.yang --print-error-code 2>&1 | diff x.expect -

--- a/test/test_issues/test_i277/Makefile
+++ b/test/test_issues/test_i277/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang -f tree x.yang 2>&1 | grep c2 > /dev/null
+	$(PYANG) -f tree x.yang 2>&1 | grep c2 > /dev/null

--- a/test/test_issues/test_i278/Makefile
+++ b/test/test_issues/test_i278/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang -f jsonxsl test.yang > /dev/null
+	$(PYANG) -f jsonxsl test.yang > /dev/null

--- a/test/test_issues/test_i285/Makefile
+++ b/test/test_issues/test_i285/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang a.yang --print-error-code 2>&1 | diff a.expect -
+	$(PYANG) a.yang --print-error-code 2>&1 | diff a.expect -
 

--- a/test/test_issues/test_i300/Makefile
+++ b/test/test_issues/test_i300/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang devext.yang > /dev/null
+	$(PYANG) devext.yang > /dev/null

--- a/test/test_issues/test_i301/Makefile
+++ b/test/test_issues/test_i301/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang > /dev/null
+	$(PYANG) a.yang > /dev/null

--- a/test/test_issues/test_i324/Makefile
+++ b/test/test_issues/test_i324/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang > /dev/null
+	$(PYANG) a.yang > /dev/null

--- a/test/test_issues/test_i329/Makefile
+++ b/test/test_issues/test_i329/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang > /dev/null
+	$(PYANG) a.yang > /dev/null

--- a/test/test_issues/test_i374/Makefile
+++ b/test/test_issues/test_i374/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang a.yang > /dev/null
-	pyang b.yang --print-error-code 2>&1 | diff b.expect -
+	$(PYANG) a.yang > /dev/null
+	$(PYANG) b.yang --print-error-code 2>&1 | diff b.expect -

--- a/test/test_issues/test_i379/Makefile
+++ b/test/test_issues/test_i379/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang --print-error-code 2>&1 | diff a.expect -
+	$(PYANG) a.yang --print-error-code 2>&1 | diff a.expect -

--- a/test/test_issues/test_i380/Makefile
+++ b/test/test_issues/test_i380/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang --lint --lint-ensure-hyphenated-names my-types.yang > /dev/null
+	$(PYANG) --lint --lint-ensure-hyphenated-names my-types.yang > /dev/null

--- a/test/test_issues/test_i475/Makefile
+++ b/test/test_issues/test_i475/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang --print-error-code test.yang --deviation-module=test-dev.yang \
+	$(PYANG) --print-error-code test.yang --deviation-module=test-dev.yang \
 	  2>&1 | diff test-dev.expect -

--- a/test/test_issues/test_i481/Makefile
+++ b/test/test_issues/test_i481/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang -f tree -F a: b.yang | diff b.expect -
+	$(PYANG) -f tree -F a: b.yang | diff b.expect -

--- a/test/test_issues/test_i482/Makefile
+++ b/test/test_issues/test_i482/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang -f tree --tree-print-groupings --tree-no-expand-uses a.yang \
+	$(PYANG) -f tree --tree-print-groupings --tree-no-expand-uses a.yang \
 	  | diff a.expect -

--- a/test/test_issues/test_i490/Makefile
+++ b/test/test_issues/test_i490/Makefile
@@ -2,8 +2,8 @@ test: test1 test2
 
 # ensure that 'qux' is NOT printed when we don't implement any features
 test1:
-	pyang -f tree -F a: a.yang | grep -q qux && exit 1 || exit 0
+	$(PYANG) -f tree -F a: a.yang | grep -q qux && exit 1 || exit 0
 
 # ensure that 'qux' IS printed when we implement all features
 test2:
-	pyang -f tree a.yang | grep -q qux
+	$(PYANG) -f tree a.yang | grep -q qux

--- a/test/test_issues/test_i493/Makefile
+++ b/test/test_issues/test_i493/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang -f yang a.yang > /dev/null
+	$(PYANG) -f yang a.yang > /dev/null
 

--- a/test/test_issues/test_i495/Makefile
+++ b/test/test_issues/test_i495/Makefile
@@ -2,7 +2,7 @@ test: test-1 test-2
 
 
 test-1:
-	pyang -Werror a.yang
+	$(PYANG) -Werror a.yang
 
 test-2:
-	pyang b.yang -Werror --print-error-code 2>&1 | diff b.expect -
+	$(PYANG) b.yang -Werror --print-error-code 2>&1 | diff b.expect -

--- a/test/test_issues/test_i505/Makefile
+++ b/test/test_issues/test_i505/Makefile
@@ -1,4 +1,4 @@
 test:
-	test `pyang -f yang --yang-canonical a.yang | grep require-instance | \
+	test `$(PYANG) -f yang --yang-canonical a.yang | grep require-instance | \
 	wc -l` = 1
 

--- a/test/test_issues/test_i509/Makefile
+++ b/test/test_issues/test_i509/Makefile
@@ -2,7 +2,7 @@ test: test-1 test-2
 
 
 test-1:
-	pyang a.yang
+	$(PYANG) a.yang
 
 test-2:
-	pyang b.yang --print-error-code 2>&1 | diff b.expect -
+	$(PYANG) b.yang --print-error-code 2>&1 | diff b.expect -

--- a/test/test_issues/test_i518/Makefile
+++ b/test/test_issues/test_i518/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang s.yang --print-error-code 2>&1 | diff s.expect -
+	$(PYANG) s.yang --print-error-code 2>&1 | diff s.expect -

--- a/test/test_issues/test_i522/Makefile
+++ b/test/test_issues/test_i522/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang -Werror c.yang
+	$(PYANG) -Werror c.yang

--- a/test/test_issues/test_i532/Makefile
+++ b/test/test_issues/test_i532/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang --print-error-code 2>&1 | diff a.expect -
+	$(PYANG) a.yang --print-error-code 2>&1 | diff a.expect -

--- a/test/test_issues/test_i536/Makefile
+++ b/test/test_issues/test_i536/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang a.yang --print-error-code 2>&1 | diff a.expect -
+	$(PYANG) a.yang --print-error-code 2>&1 | diff a.expect -

--- a/test/test_issues/test_i537/Makefile
+++ b/test/test_issues/test_i537/Makefile
@@ -1,3 +1,3 @@
 test:
-	pyang c.yang
+	$(PYANG) c.yang
 

--- a/test/test_issues/test_i538/Makefile
+++ b/test/test_issues/test_i538/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang --print-error-code mod1.yang 2>&1 | diff mod1.expect -
+	$(PYANG) --print-error-code mod1.yang 2>&1 | diff mod1.expect -

--- a/test/test_issues/test_i543/Makefile
+++ b/test/test_issues/test_i543/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang -f yang mod1.yang 2>&1 | diff expect/mod1.out -
+	$(PYANG) -f yang mod1.yang 2>&1 | diff expect/mod1.out -

--- a/test/test_issues/test_i545/Makefile
+++ b/test/test_issues/test_i545/Makefile
@@ -1,7 +1,7 @@
 test: test1 test2
 
 test1:
-	pyang mod1.yang --print-error-code 2>&1 | diff mod1.expect -
+	$(PYANG) mod1.yang --print-error-code 2>&1 | diff mod1.expect -
 
 test2:
-	pyang mod2.yang --print-error-code 2>&1 | diff mod2.expect -
+	$(PYANG) mod2.yang --print-error-code 2>&1 | diff mod2.expect -

--- a/test/test_issues/test_o001/Makefile
+++ b/test/test_issues/test_o001/Makefile
@@ -1,2 +1,2 @@
 test:
-	pyang --plugindir plugins m.yang 2>&1 | diff expect/m.out -
+	$(PYANG) --plugindir plugins m.yang 2>&1 | diff expect/m.out -

--- a/test/test_json/Makefile
+++ b/test/test_json/Makefile
@@ -22,17 +22,17 @@ compare: $(BASE)-$(TARGET).json $(JINSTANCE)
 model.xsl: hello.xml $(MODULES)
 	@echo
 	@echo == Generating $@
-	@pyang -o $@ -f jsonxsl --hello $<
+	@$(PYANG) -o $@ -f jsonxsl --hello $<
 
 model.jtox: hello.xml $(MODULES)
 	@echo
 	@echo == Generating $@
-	@pyang -o $@ -f jtox --hello $<
+	@$(PYANG) -o $@ -f jtox --hello $<
 
 $(XINSTANCE): model.jtox $(BASE)-$(TARGET).json
 	@echo
 	@echo == Generating $@
-	@json2xml -t $(TARGET) -o $@ $^
+	@$(JSON2XML) -t $(TARGET) -o $@ $^
 
 $(JINSTANCE): model.xsl $(XINSTANCE)
 	@echo
@@ -40,7 +40,7 @@ $(JINSTANCE): model.xsl $(XINSTANCE)
 	@xsltproc -o $@ $^
 
 $(SCHEMAS): hello.xml $(MODULES)
-	@yang2dsdl -L $(Y2DOPTS) $<
+	@$(YANG2DSDL) -L $(Y2DOPTS) $<
 
 %.rnc: %.rng
 	@trang -I rng -O rnc $< $@
@@ -49,4 +49,4 @@ clean:
 	@rm -f $(SCHEMAS) $(XINSTANCE) $(JINSTANCE) model.* *-gdefs.rng *.rnc
 
 validate: $(XINSTANCE) $(SCHEMAS)
-	@yang2dsdl -s -j $(Y2DOPTS) -v $<
+	@$(YANG2DSDL) -s -j $(Y2DOPTS) -v $<

--- a/test/test_prune/Makefile
+++ b/test/test_prune/Makefile
@@ -1,4 +1,4 @@
-PYANG = pyang --features a:foo,fox --features b:foo --deviation-module d.yang
+PYANG := $(PYANG) --features a:foo,fox --features b:foo --deviation-module d.yang
 
 MODULES = a.yang b.yang
 

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -1,90 +1,90 @@
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test14 test15 test16 test17 test18 test19
 test1:
 	# Test help
-	pyang --sid-help 2>&1 | diff -b test-1-expected-output.txt -
+	$(PYANG) --sid-help 2>&1 | diff -b test-1-expected-output.txt -
 
 test2:
 	# Test generate sid file
-	pyang --sid-list --sid-generate-file 20000:25 toaster@2009-11-20.yang 2>&1 | diff -b test-2-expected-output.txt -
+	$(PYANG) --sid-list --sid-generate-file 20000:25 toaster@2009-11-20.yang 2>&1 | diff -b test-2-expected-output.txt -
 	diff -b test-2-expected-toaster@2009-11-20.sid toaster@2009-11-20.sid
 	rm toaster@2009-11-20.sid
 
 test3:
 	# Test update sid file
 	cp test-2-expected-toaster@2009-11-20.sid toaster@2009-11-20.sid
-	pyang --sid-list --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-3-expected-output.txt -
+	$(PYANG) --sid-list --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-3-expected-output.txt -
 	diff -b test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
 	rm toaster@2009-11-20.sid toaster@2009-12-28.sid
 
 test4:
 	# Test check sid file
 	cp test-2-expected-toaster@2009-11-20.sid toaster@2009-11-20.sid
-	pyang --sid-list --sid-check-file toaster@2009-11-20.sid toaster@2009-11-20.yang 2>&1 | diff -b test-4-expected-output.txt -
+	$(PYANG) --sid-list --sid-check-file toaster@2009-11-20.sid toaster@2009-11-20.yang 2>&1 | diff -b test-4-expected-output.txt -
 	rm toaster@2009-11-20.sid
 
 test5:
 	# Test augment and yang data
-	pyang --sid-generate-file 2500:50 ietf-constrained-voucher@2019-08-01.yang 2>&1 | diff -b test-5-expected-output.txt -
+	$(PYANG) --sid-generate-file 2500:50 ietf-constrained-voucher@2019-08-01.yang 2>&1 | diff -b test-5-expected-output.txt -
 	diff -b test-5-expected-ietf-constrained-voucher@2019-08-01.sid ietf-constrained-voucher@2019-08-01.sid
 	rm ietf-constrained-voucher@2019-08-01.sid
   
 test6:
 	# Test SID range exhausted
 	cp test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
-	pyang --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang 2>&1 | diff -b test-6-expected-output.txt - 
+	$(PYANG) --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang 2>&1 | diff -b test-6-expected-output.txt - 
 	rm toaster@2009-12-28.sid
 
 test7:
 	# Test extra SID range
 	cp test-2-expected-toaster@2009-11-20.sid toaster@2009-11-20.sid
-	pyang --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang --sid-extra-range 20010:10 2>&1 | diff -b test-7b-expected-output.txt -
+	$(PYANG) --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang --sid-extra-range 20010:10 2>&1 | diff -b test-7b-expected-output.txt -
 	cp test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
-	pyang --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang --sid-extra-range 20100:25 2>&1 | diff -b test-7-expected-output.txt -
+	$(PYANG) --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang --sid-extra-range 20100:25 2>&1 | diff -b test-7-expected-output.txt -
 	diff -b test-7-expected-toaster@2019-01-01.sid toaster@2019-01-01.sid
 	rm -f toaster@2009-11-20.sid toaster@2009-12-28.sid toaster@2019-01-01.sid
 
 test8:
 	# In generate sid file, test count 
-	pyang --sid-generate-file count toaster@2009-11-20.yang 2>&1 | diff -b test-8-expected-output.txt -
+	$(PYANG) --sid-generate-file count toaster@2009-11-20.yang 2>&1 | diff -b test-8-expected-output.txt -
 
 test9:
 	# In generate sid file, test invalid SID range
-	pyang --sid-generate-file 2000025 toaster@2009-11-20.yang 2>&1 | diff -b test-9-expected-output.txt -
+	$(PYANG) --sid-generate-file 2000025 toaster@2009-11-20.yang 2>&1 | diff -b test-9-expected-output.txt -
 
 test10:
 	# In generate sid file, test invalid yang filename
-	pyang --sid-list --sid-generate-file 20000:25 test10-bad-toaster@2009-11-20.yang 2>&1 | diff -b test-10-expected-output.txt -
+	$(PYANG) --sid-list --sid-generate-file 20000:25 test10-bad-toaster@2009-11-20.yang 2>&1 | diff -b test-10-expected-output.txt -
 
 test11:
 	# In generate sid file, test yang file not found
-	pyang --sid-generate-file 20000:25 toaster@2009-01-01.yang 2>&1 | diff -b test-11-expected-output.txt -
+	$(PYANG) --sid-generate-file 20000:25 toaster@2009-01-01.yang 2>&1 | diff -b test-11-expected-output.txt -
 
 test12:
 	# In update sid file, test count
 	cp test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
-	pyang --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang --sid-extra-range count 2>&1 | diff -b test-12-expected-output.txt -
+	$(PYANG) --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang --sid-extra-range count 2>&1 | diff -b test-12-expected-output.txt -
 	rm toaster@2009-12-28.sid
 
 test14:
 	# In update sid file, test yang file not found
-	pyang --sid-update-file toaster@2009-11-20.sid toaster2009-12-29.yang 2>&1 | diff -b test-14-expected-output.txt -
+	$(PYANG) --sid-update-file toaster@2009-11-20.sid toaster2009-12-29.yang 2>&1 | diff -b test-14-expected-output.txt -
 
 test15:
 	# In update sid file, test invalid sid file
-	pyang --sid-update-file test15-bad-toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-15-expected-output.txt -
+	$(PYANG) --sid-update-file test15-bad-toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-15-expected-output.txt -
 
 test16:
 	# In update sid file, test invalid JSON format
-	pyang --sid-update-file test16-bad-toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-16-expected-output.txt -
+	$(PYANG) --sid-update-file test16-bad-toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-16-expected-output.txt -
 
 test17:
 	# In update sid file, test sid file not found
-	pyang --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-17-expected-output.txt -
+	$(PYANG) --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-17-expected-output.txt -
 
 test18:
 	# In checksid file, test yang file not found
-	pyang --sid-check-file toaster@2009-11-20.sid toaster.yang 2>&1 | diff -b test-18-expected-output.txt -
+	$(PYANG) --sid-check-file toaster@2009-11-20.sid toaster.yang 2>&1 | diff -b test-18-expected-output.txt -
 
 test19:
 	# In checksid file, test test sid file not found
-	pyang --sid-check-file toaster@2009-11-20.sid toaster@2009-11-20.yang 2>&1 | diff -b test-19-expected-output.txt -
+	$(PYANG) --sid-check-file toaster@2009-11-20.sid toaster@2009-11-20.yang 2>&1 | diff -b test-19-expected-output.txt -

--- a/test/test_transform/Makefile
+++ b/test/test_transform/Makefile
@@ -1,4 +1,4 @@
-PYANG = pyang -Wnone
+PYANG := $(PYANG) -Wnone
 
 MODULES ?= $(wildcard *.yang)
 

--- a/test/test_tree/Makefile
+++ b/test/test_tree/Makefile
@@ -1,21 +1,21 @@
 test: test1 test2 test3 test4 test5 test6
 
 test1:
-	pyang -f tree x.yang --tree-line-length 10 | diff x.tree.10.expect -
+	$(PYANG) -f tree x.yang --tree-line-length 10 | diff x.tree.10.expect -
 
 test2:
-	pyang -f tree x.yang --tree-line-length 50 | diff x.tree.50.expect -
+	$(PYANG) -f tree x.yang --tree-line-length 50 | diff x.tree.50.expect -
 
 test3:
-	pyang -f tree x.yang --tree-line-length 1000 | diff x.tree.expect -
+	$(PYANG) -f tree x.yang --tree-line-length 1000 | diff x.tree.expect -
 
 test4:
-	pyang -f tree x.yang | diff x.tree.expect -
+	$(PYANG) -f tree x.yang | diff x.tree.expect -
 
 test5:
 	# Baseline test before using module name as prefix
-	pyang -f tree interfaces-ext.yang ietf-interfaces.yang | diff ietf-interfaces.tree.expect -
+	$(PYANG) -f tree interfaces-ext.yang ietf-interfaces.yang | diff ietf-interfaces.tree.expect -
 
 test6:
 	# Use module name as prefix
-	pyang -f tree --tree-module-name-prefix interfaces-ext.yang ietf-interfaces.yang | diff ietf-interfaces-ext.tree.expect -
+	$(PYANG) -f tree --tree-module-name-prefix interfaces-ext.yang ietf-interfaces.yang | diff ietf-interfaces-ext.tree.expect -

--- a/test/test_update/Makefile
+++ b/test/test_update/Makefile
@@ -1,4 +1,4 @@
-PYANG = pyang --print-error-code --check-update-from
+PYANG := $(PYANG) --print-error-code --check-update-from
 
 MODULES = a c f h i
 DEVIATION_MODULES = d e

--- a/test/test_verbose/Makefile
+++ b/test/test_verbose/Makefile
@@ -1,4 +1,4 @@
-PYANG = pyang -Wnone
+PYANG := $(PYANG) -Wnone
 
 MODULES ?= $(wildcard *.yang)
 

--- a/test/test_xml/Makefile
+++ b/test/test_xml/Makefile
@@ -1,7 +1,7 @@
 #
 # Just drop .mib files here and do make all; make gen-xml
 #
-PYANG ?= pyang -Wnone
+PYANG := $(PYANG) -Wnone
 # need smidump 0.4.7 or later
 SMIDUMP ?= smidump
 

--- a/test/test_xpath/Makefile
+++ b/test/test_xpath/Makefile
@@ -1,7 +1,7 @@
 DIRS = $(shell for d in test_* ; \
 	do [ -d $$d -a -f $$d/Makefile ] && echo $$d ; done)
 
-PYANG = pyang --print-error-code --strict
+PYANG := $(PYANG) --print-error-code --strict
 
 MODULES = $(wildcard *.yang)
 

--- a/test/test_yang/Makefile
+++ b/test/test_yang/Makefile
@@ -1,4 +1,4 @@
-PYANG = pyang -Wnone
+PYANG := $(PYANG) -Wnone
 
 MODULES ?= $(wildcard *.yang)
 


### PR DESCRIPTION
Run, but do not fail on pylint; as you can see, the report is extensive. The .pylintrc file controls which issues to report on (or rather ignore).

All test invocations are now converted to a coverage run; will see how it will look like in travis and coveralls.