### PR TITLE
Add extended Hello parsing of deviations

### DIFF
--- a/bin/pyang
+++ b/bin/pyang
@@ -154,6 +154,11 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                              action="store_true",
                              help="Filename of a server's hello message is "
                              "given instead of module filename(s)."),
+        optparse.make_option("--implicit-hello-deviations",
+                             dest="implicit_hello_deviations",
+                             action="store_true",
+                             help="Attempt to parse all deviations from hello "
+                             "message regardless of declaration."),
         optparse.make_option("--keep-comments",
                              dest="keep_comments",
                              action="store_true",
@@ -359,8 +364,8 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
         m = ctx.add_module(filename, text)
         if m is not None:
             ctx.deviation_modules.append(m)
-    if o.hello:
-        for deviation_module in hel.yang_deviation_modules():
+    if o.hello and o.implicit_hello_deviations:
+        for deviation_module in hel.yang_implicit_deviation_modules():
             m = ctx.search_module(error.Position(''), deviation_module)
             if m is not None:
                 ctx.deviation_modules.append(m)

--- a/bin/pyang
+++ b/bin/pyang
@@ -359,6 +359,11 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
         m = ctx.add_module(filename, text)
         if m is not None:
             ctx.deviation_modules.append(m)
+    if o.hello:
+        for deviation_module in hel.yang_deviation_modules():
+            m = ctx.search_module(error.Position(''), deviation_module)
+            if m is not None:
+                ctx.deviation_modules.append(m)
 
     for p in plugin.plugins:
         p.pre_validate_ctx(ctx, modules)

--- a/doc/pyang.1.dbk
+++ b/doc/pyang.1.dbk
@@ -53,6 +53,7 @@
       <arg choice="opt">--features <replaceable>features</replaceable></arg>
       <arg choice="opt">--max-status <replaceable>maxstatus</replaceable></arg>
       <arg choice="opt">--hello</arg>
+      <arg choice="opt">--implicit-hello-deviations</arg>
       <arg choice="opt">--check-update-from <replaceable>oldfile</replaceable></arg>
       <arg choice="opt">-o <replaceable>outfile</replaceable></arg>
       <arg choice="opt">-t <replaceable>transform</replaceable></arg>
@@ -436,6 +437,20 @@
             Interpret the input file or standard input as a server
             &lt;hello&gt; message. In this case, no more than one
             <replaceable>file</replaceable> parameter may be given.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--implicit-hello-deviations</option>
+        </term>
+        <listitem>
+          <para>
+            Attempt to parse all deviations from a supplied &lt;hello&gt;
+            message. Not all implementations provide deviations explicitly
+            as modules. This flag enables more logic to attempt to derive
+            all deviations from the message.
           </para>
         </listitem>
       </varlistentry>

--- a/man/man1/pyang.1
+++ b/man/man1/pyang.1
@@ -31,7 +31,7 @@
 pyang \- validate and convert YANG modules to various formats
 .SH "SYNOPSIS"
 .HP \w'\fBpyang\fR\ 'u
-\fBpyang\fR [\-\-verbose] [\-\-canonical] [\-\-strict] [\-\-lint] [\-\-ietf] [\-\-lax\-quote\-checks] [\-\-lax\-xpath\-checks] [\-\-features\ \fIfeatures\fR] [\-\-max\-status\ \fImaxstatus\fR] [\-\-hello] [\-\-check\-update\-from\ \fIoldfile\fR] [\-o\ \fIoutfile\fR] [\-t\ \fItransform\fR] [\-f\ \fIformat\fR] [\-p\ \fIpath\fR] [\-W\ \fIwarning\fR] [\-E\ \fIerror\fR] \fIfile\fR...
+\fBpyang\fR [\-\-verbose] [\-\-canonical] [\-\-strict] [\-\-lint] [\-\-ietf] [\-\-lax\-quote\-checks] [\-\-lax\-xpath\-checks] [\-\-features\ \fIfeatures\fR] [\-\-max\-status\ \fImaxstatus\fR] [\-\-hello] [\-\-implicit\-hello\-deviations] [\-\-check\-update\-from\ \fIoldfile\fR] [\-o\ \fIoutfile\fR] [\-t\ \fItransform\fR] [\-f\ \fIformat\fR] [\-p\ \fIpath\fR] [\-W\ \fIwarning\fR] [\-E\ \fIerror\fR] \fIfile\fR...
 .HP \w'\fBpyang\fR\ 'u
 \fBpyang\fR [\-\-sid\-list] \-\-sid\-generate\-file {count | \fIentry\-point:size\fR} \fIyang\-filename\fR
 .HP \w'\fBpyang\fR\ 'u
@@ -230,6 +230,11 @@ Lax checks of XPath expressions\&. Specifically, do not generate an error if an 
 Interpret the input file or standard input as a server <hello> message\&. In this case, no more than one
 \fIfile\fR
 parameter may be given\&.
+.RE
+.PP
+\fB\-\-implicit\-hello\-deviations\fR
+.RS 4
+Attempt to parse all deviations from a supplied <hello> message\&. Not all implementations provide deviations explicitly as modules\&. This flag enables more logic to attempt to derive all deviations from the message\&.
 .RE
 .PP
 \fB\-\-trim\-yin\fR

--- a/pyang/hello.py
+++ b/pyang/hello.py
@@ -81,9 +81,12 @@ class HelloParser:
         res = {}
         for c in self.capabilities:
             m = c.parameters.get("module")
-            if m is None or m in res:
-                continue
-            res[m] = c.parameters.get("revision")
+            if m is not None and m not in res:
+                res[m] = c.parameters.get("revision")
+            d = c.parameters.get("deviations")
+            if d is not None and d not in res:
+                # Revision not included so we don't know...
+                res[d] = None
         return res.items()
 
     def get_features(self, yam):

--- a/pyang/hello.py
+++ b/pyang/hello.py
@@ -81,13 +81,21 @@ class HelloParser:
         res = {}
         for c in self.capabilities:
             m = c.parameters.get("module")
-            if m is not None and m not in res:
-                res[m] = c.parameters.get("revision")
-            d = c.parameters.get("deviations")
-            if d is not None and d not in res:
-                # Revision not included so we don't know...
-                res[d] = None
+            if m is None or m in res.keys():
+                continue
+            res[m] = c.parameters.get("revision")
         return res.items()
+    
+    def yang_deviation_modules(self):
+        """
+        Return a list of advertised deviations to YANG mdoules.
+        """
+        deviations = set()
+        for c in self.capabilities:
+            deviation = c.parameters.get("deviations")
+            if deviation:
+                deviations.add(deviation)
+        return deviations
 
     def get_features(self, yam):
         """Return list of features declared for module `yam`."""

--- a/pyang/hello.py
+++ b/pyang/hello.py
@@ -86,14 +86,20 @@ class HelloParser:
             res[m] = c.parameters.get("revision")
         return res.items()
     
-    def yang_deviation_modules(self):
+    def yang_implicit_deviation_modules(self):
         """
-        Return a list of advertised deviations to YANG mdoules.
+        Return an iterable of deviations to YANG modules which are referenced
+        but not explicitly advertised as a module.
         """
         deviations = set()
+        advertised_modules = set(dict(self.yang_modules()).keys())
         for c in self.capabilities:
-            deviation = c.parameters.get("deviations")
-            if deviation:
+            deviation_string = c.parameters.get("deviations")
+            if not deviation_string:
+                continue
+            for deviation in deviation_string.split(","):
+                if not deviation or deviation in advertised_modules:
+                    continue
                 deviations.add(deviation)
         return deviations
 


### PR DESCRIPTION
EDIT: Added `--implicit-hello-deviations` flag to preserve original behavior. When flag is set, then will attempt to parse deviations from hello file which were not advertised as their own module.

Currently `deviations` specified in hello messages, e.g. `capabilities-ncs5500.xml`, etc. from YangModels/yang Cisco directories are not handled resulting in a schema which does not reflect the reality of those deviations. This adds logic to parse those deviations from the hello message.

e.g. https://github.com/YangModels/yang/blob/master/vendor/cisco/xr/701/cisco-xr-openconfig-routing-policy-deviations.yang#L33

Master:
```bash
(pyang) [701] grep neighbor-sets ncs5500-tree-orig.txt
     |  +--rw neighbor-sets
                 |  |  |  +--rw neighbor-set?        -> /routing-policy/defined-sets/neighbor-sets/neighbor-set/neighbor-set-name
                 |  |     +--ro neighbor-set?        -> /routing-policy/defined-sets/neighbor-sets/neighbor-set/neighbor-set-name
```

PR:
```bash
(pyang) [701] grep neighbor-sets ncs5500-tree.txt
```

Fixes #530 