### PR TITLE
Some further fixes to make test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ schemas.xml
 *.egg-info
 *.idea
 .coverage*
+.profile*
 /test/test_*/*.dsrl
 /test/test_*/*.rng
 /test/test_*/*.sch

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
   - source env.sh
   - export USE_VIRTUALENV=true
-  - make test
+  - make pylint test TEST_MODE=coverage
   - find . -name '.coverage*' -exec mv -t . {} +
   - coverage combine
   # Test .gitignore for tests:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ sdist: build
 dist: build
 	python setup.py sdist
 
-.PHONY:	test tags clean doc build lint
+.PHONY:	test tags clean doc build lint pylint
 build: doc pyang/xpath_parsetab.py
 
 doc:
@@ -23,6 +23,8 @@ test: lint
 
 lint:
 	flake8 .
+
+pylint:
 	touch bin/__init__.py  # makes pylint tell pyang script apart from pyang package
 	pylint bin/pyang bin/json2xml bin/yang2html pyang $(shell find test -name '*.py') || true
 	rm -f bin/__init__.py
@@ -33,8 +35,8 @@ clean:
 	(cd doc &&  $(MAKE) clean)
 	python setup.py clean --all
 	rm -rf build dist MANIFEST
-	find . -name "*.pyc" -exec rm {} \;
-	find . -name "__pycache__" -exec rm -rf {} \;
+	find . -name "*.pyc" -delete
+	find . -name "__pycache__" -delete
 
 tags:
 	find . -name "*.py" | etags -

--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -385,30 +385,34 @@ class FileRepository(Repository):
         """
 
         Repository.__init__(self)
-        self.dirs = path.split(os.pathsep)
+        self.dirs = []
         self.no_path_recurse = no_path_recurse
         self.modules = None
         self.verbose = verbose
+
+        for directory in path.split(os.pathsep):
+            self._add_directory(directory)
 
         while use_env:
             use_env = False
             modpath = os.getenv('YANG_MODPATH')
             if modpath is not None:
-                self.dirs.extend(p for p in modpath.split(os.pathsep) if p)
+                for directory in modpath.split(os.pathsep):
+                    self._add_directory(directory)
 
             home = os.getenv('HOME')
             if home is not None:
-                self.dirs.append(os.path.join(home, 'yang', 'modules'))
+                self._add_directory(os.path.join(home, 'yang', 'modules'))
 
             inst = os.getenv('YANG_INSTALL')
             if inst is not None:
-                self.dirs.append(os.path.join(inst, 'yang', 'modules'))
+                self._add_directory(os.path.join(inst, 'yang', 'modules'))
                 break  # skip search if install location is indicated
 
-            default_install = os.path.join(sys.prefix,
-                                           'share','yang','modules')
+            default_install = os.path.join(
+                sys.prefix, 'share', 'yang', 'modules')
             if os.path.exists(default_install):
-                self.dirs.append(default_install)
+                self._add_directory(default_install)
                 break  # end search if default location exists
 
             # for some systems, sys.prefix returns `/usr`
@@ -432,13 +436,18 @@ class FileRepository(Repository):
                 except:
                     pass
             if location is not None:
-                self.dirs.append(os.path.join(location['data'],
-                                              'share','yang','modules'))
+                self._add_directory(
+                    os.path.join(location['data'], 'share', 'yang', 'modules'))
 
         if verbose:
             sys.stderr.write('# module search path: %s\n'
                              % os.pathsep.join(self.dirs))
 
+    def _add_directory(self, directory):
+        if not directory or directory in self.dirs:
+            return False
+        self.dirs.append(directory)
+        return True
 
     def _setup(self, ctx):
         # check all dirs for yang and yin files

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,22 @@
 DIRS = $(shell for d in test_* ; \
 	do [ -d $$d -a -f $$d/Makefile ] && echo $$d ; done)
+
+ifeq "$(TEST_MODE)" "coverage"
 COVERAGE := python -mcoverage run --branch --parallel-mode --source $(W)/pyang,$(W)/bin --omit $(W)/pyang/yacc.py
 export PYANG := $(COVERAGE) $(W)/bin/pyang
 export JSON2XML := $(COVERAGE) $(W)/bin/json2xml
 export YANG2HTML := $(COVERAGE) $(W)/bin/yang2html
-export YANG2DSDL := env PYANG='$(PYANG)' $(W)/bin/yang2dsdl
+else ifeq "$(TEST_MODE)" "profile"
+PROFILE := python -mcProfile -o .profile-`date +%M.%S.%N`
+export PYANG := $(PROFILE) $(W)/bin/pyang
+export JSON2XML := $(PROFILE) $(W)/bin/json2xml
+export YANG2HTML := $(PROFILE) $(W)/bin/yang2html
+else
+export PYANG := pyang
+export JSON2XML := json2xml
+export YANG2HTML := yang2html
+endif
+export YANG2DSDL := env PYANG="$(PYANG)" $(W)/bin/yang2dsdl
 
 test:
 	$(MAKE) selftest mtest itest
@@ -26,8 +38,8 @@ selftest:
 mtest:
 	@echo "validate all modules...";				\
 	for d in ../modules/*; do					\
-		( cd $$d;						\
-		for m in *.yang; do					\
+		( export YANG_MODPATH="$$d:$$YANG_MODPATH";		\
+		for m in $$d/*.yang; do					\
 			echo "  $${m}... " | tr -d '\012';		\
 			$(PYANG) -Werror $$m || exit 1;			\
 			echo "ok";					\
@@ -53,6 +65,7 @@ python3:
 
 clean:
 	@find -name '.coverage*' -delete;				\
+	find -name '.profile*' -delete;					\
 	for d in $(DIRS); do 						\
 		  (cd $$d && $(MAKE) $@)				\
 	done;								\

--- a/test/test_issues/test_i505/Makefile
+++ b/test/test_issues/test_i505/Makefile
@@ -1,4 +1,3 @@
 test:
-	test `$(PYANG) -f yang --yang-canonical a.yang | grep require-instance | \
-	wc -l` = 1
+	$(PYANG) -f yang --yang-canonical a.yang | grep -c require-instance | grep '^1$$'
 

--- a/test/test_verbose/Makefile
+++ b/test/test_verbose/Makefile
@@ -4,14 +4,18 @@ MODULES ?= $(wildcard *.yang)
 
 SEDSCRIPT = sed -e 's/[^-]*//' -e 's/\.yang//' -e 's/--/ --/g'
 
+HOME := $(shell pwd)/out
+SYSPREF := $(shell python -c 'import sys; print(sys.prefix)')
+SEDEXPR := "s:_HOME_:$(HOME):g;s:_ROOT_:$(W):g;s:_SYS_PREFIX_:$(SYSPREF):g"
+
 test: clean out
 	@for m in $(MODULES); do 					\
 	  echo "trying $$m..." | tr -d '\012';				\
 	  x=`echo $$m | $(SEDSCRIPT)`;					\
 	  o=`echo $$m | sed -e 's/\.yang/.stderr/'`;			\
-	  $(PYANG) --verbose $$x $$m 2>out/$$o				\
+	  HOME=$(HOME) $(PYANG) --verbose $$x $$m 2>out/$$o		\
 	    || exit 1;							\
-	  diff expect/$$o out/$$o > $$o.diff 				\
+	  sed -e $(SEDEXPR) expect/$$o | diff - out/$$o > $$o.diff	\
 	    || { cat $$o.diff; exit 1; };				\
 	  rm -f $$o.diff;						\
 	  echo " ok";							\

--- a/test/test_verbose/expect/a.stderr
+++ b/test/test_verbose/expect/a.stderr
@@ -1,3 +1,3 @@
-# module search path: .:_ROOT_/modules:_ROOT_/modules:_HOME_/yang/modules:_SYS_PREFIX_/share/yang/modules
+# module search path: .:_ROOT_/modules:_HOME_/yang/modules:_SYS_PREFIX_/share/yang/modules
 # read a.yang (CL)
 # read b.yang

--- a/test/test_verbose/expect/a.stderr
+++ b/test/test_verbose/expect/a.stderr
@@ -1,2 +1,3 @@
+# module search path: .:_ROOT_/modules:_ROOT_/modules:_HOME_/yang/modules:_SYS_PREFIX_/share/yang/modules
 # read a.yang (CL)
 # read b.yang

--- a/test/test_verbose/expect/b.stderr
+++ b/test/test_verbose/expect/b.stderr
@@ -1,2 +1,2 @@
-# module search path: .:_ROOT_/modules:_ROOT_/modules:_HOME_/yang/modules:_SYS_PREFIX_/share/yang/modules
+# module search path: .:_ROOT_/modules:_HOME_/yang/modules:_SYS_PREFIX_/share/yang/modules
 # read b.yang (CL)

--- a/test/test_verbose/expect/b.stderr
+++ b/test/test_verbose/expect/b.stderr
@@ -1,1 +1,2 @@
+# module search path: .:_ROOT_/modules:_ROOT_/modules:_HOME_/yang/modules:_SYS_PREFIX_/share/yang/modules
 # read b.yang (CL)


### PR DESCRIPTION
Long story: While preparing a patch for selftest, and general unification of file handling, I noticed make test took 3x more in my python3 virtualenv than normal. 

The reason was the import pip with an old pip (9.0.1 ships with bionic), vs. latest in my python2 virtualenv. E.g. setting YANG_INSTALL=$PWD skipped those imports, and the total runtime was comparable with current pips.

At least some improvements to the makefiles can be derived from that.