### PR TITLE
#547 feature:keep end-of-line comments

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2963,6 +2963,11 @@ class BitStatement(Statement):
         'i_position',
     )
 
+class CommentStatement(Statement):
+    __slots__ = (
+        'i_line_end',
+        'i_multi_line',
+    )
 
 class ChoiceStatement(Statement):
     __slots__ = (
@@ -3101,6 +3106,7 @@ STMT_CLASS_FOR_KEYWD = {
     'uses': UsesStatement,
     'must': MustStatement,
     'when': WhenStatement,
+    '_comment': CommentStatement,
     # all other keywords can use generic Statement class
 }
 

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -46,7 +46,12 @@ class YANGPlugin(plugin.PyangPlugin):
         emit_yang(ctx, module, fd)
 
 def emit_yang(ctx, module, fd):
-    emit_stmt(ctx, module, fd, 0, None, None, False, '', '  ')
+    link_list = {}
+    # make the stmt tree to a link_list, in order to peek the next stmt
+    make_link_list(ctx, module, link_list)
+    link_list['last'] = None
+
+    emit_stmt(ctx, module, fd, 0, None, None, False, '', '  ', link_list)
 
 # always add newline between keyword and argument
 _force_newline_arg = ('description', 'reference', 'contact', 'organization')
@@ -133,8 +138,25 @@ _need_quote = (
     "\n", "\t", "\r", "//", "/*", "*/",
     )
 
+def make_link_list(ctx, stmt, link_list):
+    if 'last' in link_list.keys():
+        link_list[ link_list['last'] ] = stmt
+    link_list['last'] = stmt
+
+    if len(stmt.substmts) > 0:
+        if ctx.opts.yang_canonical:
+            substmts = grammar.sort_canonical(stmt.keyword, stmt.substmts)
+        else:
+            substmts = stmt.substmts
+        for i, s in enumerate(substmts, start=1):
+            make_link_list(ctx, s, link_list)
+
 def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
-              indent, indentstep):
+              indent, indentstep, link_list):
+    # line end comment has been printed
+    if is_line_end_comment(stmt):
+        return
+
     if ctx.opts.yang_remove_unused_imports and stmt.keyword == 'import':
         for p in stmt.parent.i_unused_prefixes:
             if stmt.parent.i_unused_prefixes[p] == stmt:
@@ -216,7 +238,12 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
         else:
             arg_on_new_line = emit_arg(keywordstr, stmt, fd, indent, indentstep,
                                        max_line_len, line_len)
-    fd.write(eol + '\n')
+    fd.write(eol)
+    next_stmt = None
+    if stmt in link_list.keys():
+        next_stmt = link_list[stmt]
+    emit_line_end_comments_after(stmt, next_stmt, link_list, fd, False)
+    fd.write('\n')
 
     if len(stmt.substmts) > 0:
         if ctx.opts.yang_canonical:
@@ -231,18 +258,44 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
             if arg_on_new_line:
                 # arg was printed on a new line, increase indentation
                 n = 2
+
+            link_list['last'] = s
             emit_stmt(ctx, s, fd, level + 1, prev_kwd, kwd_class,
                       i == len(substmts),
-                      indent + (indentstep * n), indentstep)
-            kwd_class = get_kwd_class(s.keyword)
-            prev_kwd = s.keyword
-        fd.write(indent + '}\n')
+                      indent + (indentstep * n), indentstep, link_list)
+            if not is_line_end_comment(s):
+                kwd_class = get_kwd_class(s.keyword)
+                prev_kwd = s.keyword
+        fd.write(indent + '}')
+        last_substmt = link_list['last']
+        if last_substmt in link_list.keys():
+            last_substmt = link_list[last_substmt]
+        emit_line_end_comments_after(stmt, last_substmt, link_list, fd, True)
+        fd.write('\n')
 
     if (not islast and
         ((level == 1 and stmt.keyword in
           _keyword_with_trailing_blank_line_toplevel) or
          stmt.keyword in _keyword_with_trailing_blank_line)):
         fd.write('\n')
+
+def emit_line_end_comments_after(stmt, last_substmt, link_list, fd, need_same_level):
+    while last_substmt is not None:
+        is_sub_level = False
+        if not need_same_level:
+            is_sub_level = last_substmt.parent == stmt
+        if (is_line_end_comment(last_substmt) and
+                (last_substmt.parent == stmt.parent or (not need_same_level and is_sub_level))):
+            fd.write('  ' + last_substmt.arg)
+            if last_substmt in link_list.keys():
+                last_substmt = link_list[last_substmt]
+            else:
+                return
+        else:
+            return
+
+def is_line_end_comment(stmt):
+    return stmt.keyword == '_comment' and stmt.is_line_end and not stmt.is_multi_line
 
 def need_new_line(max_line_len, line_len, arg):
     eol = arg.find('\n')

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -1,6 +1,7 @@
 """YANG output plugin"""
 
 import optparse
+import sys
 
 from .. import plugin
 from .. import util
@@ -139,7 +140,7 @@ _need_quote = (
     )
 
 def make_link_list(ctx, stmt, link_list):
-    if 'last' in link_list.keys():
+    if dict_has_key(link_list, 'last'):
         link_list[ link_list['last'] ] = stmt
     link_list['last'] = stmt
 
@@ -240,7 +241,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
                                        max_line_len, line_len)
     fd.write(eol)
     next_stmt = None
-    if stmt in link_list.keys():
+    if dict_has_key(link_list, stmt):
         next_stmt = link_list[stmt]
     emit_line_end_comments_after(stmt, next_stmt, link_list, fd, False)
     fd.write('\n')
@@ -268,7 +269,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
                 prev_kwd = s.keyword
         fd.write(indent + '}')
         last_substmt = link_list['last']
-        if last_substmt in link_list.keys():
+        if dict_has_key(link_list, last_substmt):
             last_substmt = link_list[last_substmt]
         emit_line_end_comments_after(stmt, last_substmt, link_list, fd, True)
         fd.write('\n')
@@ -287,7 +288,7 @@ def emit_line_end_comments_after(stmt, last_substmt, link_list, fd, need_same_le
         if (is_line_end_comment(last_substmt) and
                 (last_substmt.parent == stmt.parent or (not need_same_level and is_sub_level))):
             fd.write(' ' + last_substmt.arg)
-            if last_substmt in link_list.keys():
+            if dict_has_key(link_list, last_substmt):
                 last_substmt = link_list[last_substmt]
             else:
                 return
@@ -296,6 +297,12 @@ def emit_line_end_comments_after(stmt, last_substmt, link_list, fd, need_same_le
 
 def is_line_end_comment(stmt):
     return stmt.keyword == '_comment' and stmt.is_line_end and not stmt.is_multi_line
+
+def dict_has_key(dict, key):
+    if sys.version < '3':
+        return dict.has_key(key)
+    else:
+        return key in dict.keys()
 
 def need_new_line(max_line_len, line_len, arg):
     eol = arg.find('\n')

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -286,7 +286,7 @@ def emit_line_end_comments_after(stmt, last_substmt, link_list, fd, need_same_le
             is_sub_level = last_substmt.parent == stmt
         if (is_line_end_comment(last_substmt) and
                 (last_substmt.parent == stmt.parent or (not need_same_level and is_sub_level))):
-            fd.write('  ' + last_substmt.arg)
+            fd.write(' ' + last_substmt.arg)
             if last_substmt in link_list.keys():
                 last_substmt = link_list[last_substmt]
             else:

--- a/pyang/yang_parser.py
+++ b/pyang/yang_parser.py
@@ -81,19 +81,23 @@ class YangTokenizer(object):
                     self.set_buf(i+2)
                     return self.skip(keep_comments=keep_comments)
 
-    def get_comment(self):
+    def get_comment(self, last_line):
         """ret: string()"""
+        is_multi_line = False
+        is_line_end = False
         self.skip(keep_comments=True)
         offset = self.offset
         m = syntax.re_comment.match(self.buf)
         if m is None:
-            return None
+            return None, is_line_end, is_multi_line
         else:
             cmt = m.group(0)
             self.set_buf(m.end())
+            is_line_end = (last_line == self.pos.line)
             # look for a multiline comment
             if cmt[:2] == '/*' and cmt[-2:] != '*/':
                 i = self.buf.find('*/')
+                is_multi_line = True
                 while i == -1:
                     self.readline()
                     # remove at most the same number of whitespace as
@@ -106,7 +110,7 @@ class YangTokenizer(object):
                     cmt += '\n'+self.buf.replace('\n','')
                     i = self.buf.find('*/')
                 self.set_buf(i+2)
-            return cmt
+            return cmt, is_line_end, is_multi_line
 
     def get_keyword(self):
         """ret: identifier | (prefix, identifier)"""
@@ -276,6 +280,7 @@ class YangParser(object):
 
         self.ctx = ctx
         self.pos = error.Position(ref)
+        self.last_line = 0
         self.top = None
         try:
             self.tokenizer = YangTokenizer(text, self.pos, ctx.errors,
@@ -302,13 +307,15 @@ class YangParser(object):
         # we would like to see if a statement is a comment, and if so
         # treat it differently than we treat keywords further down
         if self.ctx.keep_comments:
-            cmt = self.tokenizer.get_comment()
+            cmt, is_line_end, is_multi_line = self.tokenizer.get_comment(self.last_line)
             if cmt is not None:
                 stmt = statements.new_statement(self.top,
                                                 parent,
                                                 self.pos,
                                                 '_comment',
                                                 cmt)
+                stmt.is_line_end = is_line_end
+                stmt.is_multi_line = is_multi_line
                 return stmt
 
         keywd = self.tokenizer.get_keyword()
@@ -337,6 +344,7 @@ class YangParser(object):
         tok = self.tokenizer.peek()
         if tok == '{':
             self.tokenizer.skip_tok() # skip the '{'
+            self.last_line = self.pos.line
             while self.tokenizer.peek() != '}':
                 substmt = self._parse_statement(stmt)
                 stmt.substmts.append(substmt)
@@ -347,6 +355,7 @@ class YangParser(object):
             error.err_add(self.ctx.errors, self.pos, 'INCOMPLETE_STATEMENT',
                           (keywd, tok))
             raise error.Abort
+        self.last_line = self.pos.line
         return stmt
 
 # FIXME: tmp debug

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,9 @@
 universal=1
 
 [flake8]
+ignore:
+    # .has_key() is deprecated, use 'in'
+    W601,
 select =
 	# E & W error codes from pycodestyle:
 	# https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes

--- a/test/test_yang/expect/b.yang
+++ b/test/test_yang/expect/b.yang
@@ -33,10 +33,7 @@ module b {
 
   container x {
     // the container is y
-    container y;
-    /* same-line comment */
+    container y;  /* same-line comment */
     container bar;
-  }
-
-  /* trailing comment */
+  }  /* trailing comment */
 }

--- a/test/test_yang/expect/b.yang
+++ b/test/test_yang/expect/b.yang
@@ -33,7 +33,7 @@ module b {
 
   container x {
     // the container is y
-    container y;  /* same-line comment */
+    container y; /* same-line comment */
     container bar;
-  }  /* trailing comment */
+  } /* trailing comment */
 }

--- a/test/test_yang/expect/h.yang
+++ b/test/test_yang/expect/h.yang
@@ -1,29 +1,29 @@
-module h {  // line end 1
+module h { // line end 1
   yang-version 1.1;
-  namespace "urn:if";  // line end 2
+  namespace "urn:if"; // line end 2
   prefix if;
 
   feature f1 {
     // not line end 3
-  }  // line end 4
+  } // line end 4
 
-  feature f2;  // line end 5
+  feature f2; // line end 5
 
   // not line end 6
 
-  leaf l1 {  /* line end 7 */
-    type string;  // line end 8
+  leaf l1 { /* line end 7 */
+    type string; // line end 8
     // not line end 9
     if-feature "f1 and f2";
-  }  /* line end10 */  /* line end11 */
+  } /* line end10 */ /* line end11 */
 
   /*   multi line 12-1
   multi line 12-2 */
 
   leaf l2 {
     type leafref {
-      path "/l1";  /* line end13 */  // line end 14
-      require-instance false;  // line end 15
+      path "/l1"; /* line end13 */ // line end 14
+      require-instance false; // line end 15
     }
-  }  // last line end 16
+  } // last line end 16
 }

--- a/test/test_yang/expect/h.yang
+++ b/test/test_yang/expect/h.yang
@@ -1,0 +1,29 @@
+module h {  // line end 1
+  yang-version 1.1;
+  namespace "urn:if";  // line end 2
+  prefix if;
+
+  feature f1 {
+    // not line end 3
+  }  // line end 4
+
+  feature f2;  // line end 5
+
+  // not line end 6
+
+  leaf l1 {  /* line end 7 */
+    type string;  // line end 8
+    // not line end 9
+    if-feature "f1 and f2";
+  }  /* line end10 */  /* line end11 */
+
+  /*   multi line 12-1
+  multi line 12-2 */
+
+  leaf l2 {
+    type leafref {
+      path "/l1";  /* line end13 */  // line end 14
+      require-instance false;  // line end 15
+    }
+  }  // last line end 16
+}

--- a/test/test_yang/h.yang
+++ b/test/test_yang/h.yang
@@ -1,0 +1,25 @@
+module h{ // line end 1
+  yang-version 1.1;
+  namespace "urn:if"; // line end 2
+  prefix if;
+
+  feature f1 {
+    // not line end 3
+  } // line end 4
+  feature f2;// line end 5
+
+  // not line end 6
+  leaf l1 {  /* line end 7 */
+    type string; // line end 8
+    // not line end 9
+    if-feature "f1 and f2";
+  }   /* line end10 */  /* line end11 */  /*   multi line 12-1
+    multi line 12-2 */
+
+  leaf l2 {
+    type leafref {
+      path "/l1"; /* line end13 */  // line end 14
+      require-instance false; // line end 15
+    }
+  }// last line end 16
+}


### PR DESCRIPTION
Hi Martin @mbj4668 ,  #547 is fixed. Please review this. 

1 It traverses the schema tree first to make a link list in order to look for the next statement to the current statement.
2 It adds two properties for the Comment Statement:`is_line_end`, `is_multi_line`. Compare current statement's position line number with the next comment's position line number for calculating the `is_line_end` property value.
3 End-of-line comments are separated by one space.
4 A test case is added in  `test_yang` module and `b.yang` has some small fixes for this feature.
