### PR TITLE
Bugfix #501: fix plugin jtox crash for models with leafref in yang-version 1.1

### DIFF
--- a/test/test_issues/test_i501/Makefile
+++ b/test/test_issues/test_i501/Makefile
@@ -1,0 +1,7 @@
+test: test1 test11
+
+test1:
+	$(PYANG) -f jtox mod1.yang > /dev/null
+
+test11:
+	$(PYANG) -f jtox mod11.yang > /dev/null

--- a/test/test_issues/test_i501/mod1.yang
+++ b/test/test_issues/test_i501/mod1.yang
@@ -1,0 +1,33 @@
+module mod1 {
+  yang-version 1;
+  namespace "urn:mod1";
+  prefix abc;
+
+  grouping gg{
+    container ggcc {
+      leaf ggccll{
+        type ref1;
+      }
+    }
+  }
+
+  typedef ref1 {
+    type ref2;
+  }
+
+  typedef ref2 {
+    type leafref {
+      path "/l2";
+    }
+  }
+
+  leaf l2{
+    type uint32;
+  }
+
+  leaf bar{
+    type ref1;
+  }
+
+  uses gg;
+}

--- a/test/test_issues/test_i501/mod11.yang
+++ b/test/test_issues/test_i501/mod11.yang
@@ -1,0 +1,33 @@
+module mod11 {
+  yang-version 1.1;
+  namespace "urn:mod11";
+  prefix abc;
+
+  grouping gg{
+    container ggcc {
+      leaf ggccll{
+        type ref1;
+      }
+    }
+  }
+
+  typedef ref1 {
+    type ref2;
+  }
+
+  typedef ref2 {
+    type leafref {
+      path "/l2";
+    }
+  }
+
+  leaf l2{
+    type uint32;
+  }
+
+  leaf bar{
+    type ref1;
+  }
+
+  uses gg;
+}


### PR DESCRIPTION
This PR fix #501   since` i_target_node` for leafref was processed differently between "yang-version 1.1" and "yang-version 1" with commit 8d7e549 , however, plugin `jtox` did not modify at the same time. So this commit fix this.