### PR TITLE
Change --edit-previous-revision-date to --edit-delete-revisions-after

### DIFF
--- a/pyang/transforms/edit.py
+++ b/pyang/transforms/edit.py
@@ -75,10 +75,10 @@ class EditPlugin(plugin.PyangPlugin):
                             "to the supplied value"),
 
             # set revision info
-            EditOption("--edit-previous-revision-date",
-                       dest="edit_previous_revision_date", type="date",
+            EditOption("--edit-delete-revisions-after",
+                       dest="edit_delete_revisions_after", type="date",
                        metavar="PREVDATE",
-                       help="Delete any revisions later than "
+                       help="Delete any revisions after "
                             "the supplied yyyy-mm-dd"),
             EditOption("--edit-revision-date", dest="edit_revision_date",
                        type="date", metavar="DATE",
@@ -177,7 +177,7 @@ def set_revision_details(ctx, stmt, lastrev):
 
     # relevant options
     opts = {
-        'olddate': ctx.opts.edit_previous_revision_date,
+        'olddate': ctx.opts.edit_delete_revisions_after,
         'newdate': ctx.opts.edit_revision_date,
         'description': ctx.opts.edit_revision_description,
         'reference': ctx.opts.edit_revision_reference


### PR DESCRIPTION
As proposed by @mbj4668, arising from this comment:

> There is one option --edit-delete-xxx to delete xxx and the rest are --edit-yyy to set yyy.  Except --edit-previous-revision-date which deletes.  How about changing it to --edit-delete-previous-revision-date?

Upon further discussion we came up with --edit-delete-revision-after, which I've changed to --edit-delete-revisions-after in this PR (because more than one revision statement can be deleted).