### PR TITLE
Bugfix #572: action or notification cannot have an ancestor list node without a "key"

### DIFF
--- a/pyang/error.py
+++ b/pyang/error.py
@@ -355,6 +355,9 @@ error_codes = \
       (1,
        'there is already a child node to "%s" at %s with the name "%s" '
        'defined at %s'),
+    'BAD_ANCESTOR':
+      (1,
+       '"%s" node cannot have an ancestor list node without a key'),
     'BAD_TYPE_NAME':
       (1,
        'illegal type name "%s"'),

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -225,6 +225,8 @@ _validation_map = {
         lambda ctx, s: v_unique_name_leaf_list(ctx, s),
 
     ('reference_1', 'list'):lambda ctx, s:v_reference_list(ctx, s),
+    ('reference_1', 'action'):lambda ctx, s:v_reference_action(ctx, s),
+    ('reference_1', 'notification'):lambda ctx, s:v_reference_notification(ctx, s),
     ('reference_1', 'choice'):lambda ctx, s: v_reference_choice(ctx, s),
     ('reference_2', 'leaf'):lambda ctx, s:v_reference_leaf_leafref(ctx, s),
     ('reference_2', 'leaf-list'):lambda ctx, s:v_reference_leaf_leafref(ctx, s),
@@ -1872,6 +1874,41 @@ def v_unique_name_leaf_list(ctx, stmt):
             seen.append(defval)
 
 ### Reference phase
+
+def v_reference_notification(ctx, stmt):
+    def iterate(s):
+        if s.parent is None:
+            return
+        else:
+            parent = s.parent
+            if parent.keyword == "list":
+                key = parent.search_one('key')
+                if parent.i_config is False and key is None and parent.i_module.i_version == '1.1':
+                    err_add(ctx.errors, stmt.pos, 'BAD_ANCESTOR', (stmt.keyword))
+                else:
+                    iterate(parent)
+            else:
+                iterate(parent)
+
+    iterate(stmt)
+
+def v_reference_action(ctx, stmt):
+    def iterate(s):
+        if s.parent is None:
+            return
+        else:
+            parent = s.parent
+            if parent.keyword == "list":
+                key = parent.search_one('key')
+                if parent.i_config is False and key is None and parent.i_module.i_version == '1.1':
+                    err_add(ctx.errors, stmt.pos, 'BAD_ANCESTOR', (stmt.keyword))
+                else:
+                    iterate(parent)
+            else:
+                iterate(parent)
+
+    iterate(stmt)
+
 
 def v_reference_list(ctx, stmt):
     if getattr(stmt, 'i_is_validated', None) is True:

--- a/test/test_bad/test_sec_7_15/expect/mod1.expect
+++ b/test/test_bad/test_sec_7_15/expect/mod1.expect
@@ -6,3 +6,4 @@ mod1.yang:24: error: DUPLICATE_CHILD_NAME
 mod1.yang:38: error: UNEXPECTED_KEYWORD
 mod1.yang:38: error: DUPLICATE_CHILD_NAME
 mod1.yang:48: error: UNEXPECTED_KEYWORD
+mod1.yang:59: error: BAD_ANCESTOR

--- a/test/test_issues/test_i572/Makefile
+++ b/test/test_issues/test_i572/Makefile
@@ -1,0 +1,7 @@
+test: test1 test2
+
+test1:
+	$(PYANG) mod1.yang --print-error-code 2>&1 | diff expect/mod1.expect -
+
+test2:
+	$(PYANG) mod2.yang --print-error-code 2>&1 | diff expect/mod2.expect -

--- a/test/test_issues/test_i572/expect/mod1.expect
+++ b/test/test_issues/test_i572/expect/mod1.expect
@@ -1,0 +1,4 @@
+mod1.yang:14: error: BAD_ANCESTOR
+mod1.yang:18: error: BAD_ANCESTOR
+mod1.yang:52 (at mod1.yang:29): error: BAD_ANCESTOR
+mod1.yang:52 (at mod1.yang:33): error: BAD_ANCESTOR

--- a/test/test_issues/test_i572/expect/mod2.expect
+++ b/test/test_issues/test_i572/expect/mod2.expect
@@ -1,0 +1,2 @@
+mod2.yang:30: error: BAD_ANCESTOR
+mod2.yang:34: error: BAD_ANCESTOR

--- a/test/test_issues/test_i572/mod1.yang
+++ b/test/test_issues/test_i572/mod1.yang
@@ -1,0 +1,61 @@
+module mod1 {
+  yang-version 1.1;
+  prefix aa;
+  namespace "urn:mod1";
+
+  list lst1 {
+    //key "name";
+    config false;
+
+    leaf name {
+      type string;
+    }
+
+    action act { // error: 'key' is missing
+      description "test description";
+    }
+
+    notification not { // error: 'key' is missing
+      description "test description";
+    }
+
+  }
+
+  grouping gg1 {
+    leaf le1 {
+      type boolean;
+    }
+
+    action act1 {
+      description "test description";
+    }
+
+    notification not1 { 
+      description "test description";
+    }
+  } 
+
+  container con {
+    list lst2 {
+      //key lle; // error: 'key' is missing 
+      config false;
+      leaf lle {
+        type string;
+      }
+
+      container con1 {
+        list lst3 {
+          key lle2;
+          leaf lle2 {
+            type empty;
+          }
+          uses gg1;
+        }
+      }
+
+    }
+  }
+
+
+
+}

--- a/test/test_issues/test_i572/mod2.yang
+++ b/test/test_issues/test_i572/mod2.yang
@@ -1,0 +1,41 @@
+module mod2 {
+  yang-version 1.1;
+  prefix aa;
+  namespace "urn:mod2";
+
+  container con1 {
+    list lst1 {
+      //key "name";
+      config false;
+
+      leaf name {
+        type string;
+      }
+     
+      container con2 {
+        list lst2 {    
+          key le1;
+
+          leaf le1 {
+            type uint16;
+          }          
+
+        }
+      }
+    }
+  }
+
+
+  augment "/con1/lst1/con2/lst2" {    
+    action act { // error: 'key' is missing
+      description "test description";
+    }
+
+    notification not { // error: 'key' is missing
+      description "test description";
+    }
+
+  }
+
+
+}


### PR DESCRIPTION
Hi Martin, this PR Fix #572 

However, there are two more situations that I'm not sure in the RFC7950 for this:

1) When the action is in a grouping, then a list node without a key uses this grouping.

2)When an augment statement including an action, and the target node is a list node without a key.
