### PR TITLE
Bugfix deviation replace/add config should check the target node's config tree

### DIFF
--- a/pyang/error.py
+++ b/pyang/error.py
@@ -190,6 +190,9 @@ error_codes = \
     'BAD_DEVIATE_ADD':
       (2,
        'the "%s" property already exists in node "%s::%s"'),
+    'BAD_DEVIATE_REP':
+      (2,
+       'the "%s" property does not exist in node "%s::%s"'),
     'BAD_DEVIATE_DEL':
       (2,
        'the "%s" property does not exist in node "%s::%s"'),

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2126,7 +2126,7 @@ def v_reference_deviate(ctx, stmt):
         else:
             p_config = node.parent.search_one('config')
             if p_config is not None and p_config.arg == 'false':
-                err_add(ctx.errors, target.pos, 'INVALID_CONFIG', ())
+                err_add(ctx.errors, c.pos, 'INVALID_CONFIG', ())
                 return True
             return search_ancestor_config_false(node.parent, target)
 
@@ -2136,7 +2136,7 @@ def v_reference_deviate(ctx, stmt):
         if node.keyword in data_definition_keywords:
             c_config = node.search_one('config')
             if c_config is not None and c_config.arg == 'true':
-                err_add(ctx.errors, target.pos, 'INVALID_CONFIG', ())
+                err_add(ctx.errors, c.pos, 'INVALID_CONFIG', ())
                 return True
         else:
             return False
@@ -2257,7 +2257,8 @@ def v_reference_deviate(ctx, stmt):
                     negc = copy.copy(old)
                     old.arg = c.arg
                 else:
-                    err_add(ctx.errors, t.pos, 'BAD_DEVIATE_REP', (c.keyword, t.i_module.arg, t.arg))
+                    err_add(ctx.errors, t.pos, 'BAD_DEVIATE_REP',
+                            (c.keyword, t.i_module.arg, t.arg))
                     continue
 
                 if c.arg == 'true':

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2196,8 +2196,7 @@ def v_reference_deviate(ctx, stmt):
                 continue
             if c.keyword == 'config' and hasattr(t, 'i_config'):
                 # config is special: since it is an inherited property
-                # with a default, all nodes has a config property.  this means
-                # that it can only be replaced.
+                # with a default, all nodes has a config property.
                 config = t.search_one(c.keyword)
                 if config is None:
                     if c.arg == 'true':
@@ -2250,11 +2249,9 @@ def v_reference_deviate(ctx, stmt):
                 continue
             if c.keyword == 'config' and hasattr(t, 'i_config'):
                 # config is special: since it is an inherited property
-                # with a default, all nodes has a config property.  this means
-                # that it can only be replaced.
-                # first, set the property...
+                # with a default, all nodes has a config property.
+                # first, save the old property, and then set the property...
 
-                # ... and then modify the original statement, if any
                 old = t.search_one(c.keyword)
                 if old is not None:
                     negc = copy.copy(old)

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2262,6 +2262,8 @@ def v_reference_deviate(ctx, stmt):
                             err_add(ctx.errors, c.pos,
                                     'INVALID_CONFIG', ())
                             continue
+                        else:
+                            t.i_config = True
                 else:
                     if search_children_config_true(t, t):
                         old.arg = negc.arg

--- a/test/test_bad/test_sec_7_20/expect/mod1.expect
+++ b/test/test_bad/test_sec_7_20/expect/mod1.expect
@@ -8,7 +8,6 @@ mod1.yang:47: error: UNEXPECTED_KEYWORD
 mod1.yang:47: error: EXPECTED_KEYWORD_2
 mod1.yang:56: error: UNEXPECTED_KEYWORD
 mod1.yang:56: error: BAD_DEVIATE_ADD
-mod1.yang:58: error: BAD_DEVIATE_ADD
 mod1.yang:59: error: UNEXPECTED_KEYWORD
 mod1.yang:59: error: BAD_DEVIATE_ADD
 mod1.yang:62: error: UNEXPECTED_KEYWORD

--- a/test/test_issues/test_i219/Makefile
+++ b/test/test_issues/test_i219/Makefile
@@ -1,0 +1,7 @@
+test: test1 test2
+
+test1:
+	$(PYANG) mod1.yang --print-error-code 2>&1 | diff expect/mod1.expect -
+
+test2:
+	$(PYANG) mod2.yang --print-error-code 2>&1 | diff expect/mod2.expect -

--- a/test/test_issues/test_i219/expect/mod1.expect
+++ b/test/test_issues/test_i219/expect/mod1.expect
@@ -1,3 +1,3 @@
-mod1.yang:9: error: INVALID_CONFIG
-mod1.yang:12: error: INVALID_CONFIG
 mod1.yang:12: error: BAD_DEVIATE_REP
+mod1.yang:38: error: INVALID_CONFIG
+mod1.yang:44: error: INVALID_CONFIG

--- a/test/test_issues/test_i219/expect/mod1.expect
+++ b/test/test_issues/test_i219/expect/mod1.expect
@@ -1,0 +1,3 @@
+mod1.yang:9: error: INVALID_CONFIG
+mod1.yang:12: error: INVALID_CONFIG
+mod1.yang:12: error: BAD_DEVIATE_REP

--- a/test/test_issues/test_i219/expect/mod2.expect
+++ b/test/test_issues/test_i219/expect/mod2.expect
@@ -1,3 +1,3 @@
-mod2.yang:6: error: INVALID_CONFIG
 mod2.yang:12: error: BAD_DEVIATE_REP
-mod2.yang:14: error: INVALID_CONFIG
+mod2.yang:44: error: INVALID_CONFIG
+mod2.yang:50: error: INVALID_CONFIG

--- a/test/test_issues/test_i219/expect/mod2.expect
+++ b/test/test_issues/test_i219/expect/mod2.expect
@@ -1,0 +1,3 @@
+mod2.yang:6: error: INVALID_CONFIG
+mod2.yang:12: error: BAD_DEVIATE_REP
+mod2.yang:14: error: INVALID_CONFIG

--- a/test/test_issues/test_i219/mod1.yang
+++ b/test/test_issues/test_i219/mod1.yang
@@ -1,0 +1,60 @@
+module mod1 {
+  yang-version 1.1;
+  namespace "urn:mod1";
+  prefix m1;
+
+  container con1 {
+    config false;
+
+    container con2 {
+      config false;
+
+      container con3 {
+
+        container con4 {
+
+          container con5 {
+            config false;
+
+            leaf le1 {
+              type boolean;
+            }
+          }
+
+          container con6 {
+            config false;
+
+            leaf le2 {
+              type string;
+            }
+          }
+        }
+      }
+    }
+  }
+ 
+  deviation "/con1/con2" {
+    deviate replace {
+      config true;
+    }
+  }
+
+  deviation "/con1/con2/con3" {
+    deviate add {
+      config true;
+    }
+  }
+
+  deviation "/con1/con2/con3" {
+    deviate replace {
+      config true;
+    }
+  }
+
+  deviation "/con1/con2/con3" {
+    deviate add {
+      config false; // additional devaite comment substatement
+    }
+  }
+
+}

--- a/test/test_issues/test_i219/mod2.yang
+++ b/test/test_issues/test_i219/mod2.yang
@@ -1,0 +1,60 @@
+module mod2 {
+  yang-version 1.1;
+  namespace "urn:mod2";
+  prefix m2;
+
+  container con1 {
+    config true;
+
+    container con2 {
+      config true;
+
+      container con3 {
+
+        container con4 {
+
+          container con5 {
+            config true;
+
+            leaf le1 {
+              type boolean;
+            }
+          }
+
+          container con6 {
+            config false;
+
+            leaf le2 {
+              type string;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  deviation /con1/con2/con3 {
+    deviate replace {
+      config false;
+    }
+  }
+
+  deviation /con1/con2/con3/con4 {
+    deviate add {
+      config false;
+    }
+  }
+
+  deviation /con1 {
+    deviate replace {
+      config false;
+    }
+  }
+
+  deviation /con1/con2/con3 {
+    deviate add {
+      config true; // addtional deviate comment substatement
+    }
+  }
+
+}

--- a/test/test_issues/test_i267/Makefile
+++ b/test/test_issues/test_i267/Makefile
@@ -1,3 +1,3 @@
 test:
 	$(PYANG) --print-error-code test.yang --deviation-module=test-dev.yang \
-	  2>&1 | grep BAD_DEVIATE_ADD > /dev/null
+	  2>&1 | grep BAD_DEVIATE_DEL2 > /dev/null


### PR DESCRIPTION
Hi, This PR fix #219 

Meanwhile, another issue is found and fixed: 

When a comment substatement is in the deviate statement, it will report an error like
```
the "_comment" property does not exist in node "main::x"
```
However, I don't think this is an error.