### PR TITLE
Validation improvements

### DIFF
--- a/pyang/error.py
+++ b/pyang/error.py
@@ -317,9 +317,6 @@ error_codes = \
     'PATTERN_ERROR':
       (2,
        'syntax error in pattern: %s'),
-    'PATTERN_FAILURE':
-      (4,
-       'could not verify pattern: %s'),
     'LEAFREF_TOO_MANY_UP':
       (1,
        'the path for %s at %s has too many ".."'),

--- a/pyang/grammar.py
+++ b/pyang/grammar.py
@@ -546,10 +546,10 @@ stmt_map = {
 Maps a statement name to a 2-tuple:
     (<argument type name> | None, <list of substatements> )
 Each substatement is a 2-tuple:
-    (<statement name>, <occurance>) |
+    (<statement name>, <occurence>) |
     ('$interleave', <list of substatements to interleave>)
     ('$choice', <list of <case>>)
-where <occurance> is one of: '?', '1', '+', '*'.
+where <occurence> is one of: '?', '1', '+', '*'.
 and <case> is a list of substatements
 """
 
@@ -668,8 +668,8 @@ def _chk_stmts(ctx, pos, stmts, parent, spec, canonical):
         # update last know position
         pos = stmt.pos
     # any non-optional statements left are errors
-    for keywd, occurance in spec[0]:
-        if occurance == '1' or occurance == '+':
+    for keywd, occurence in spec[0]:
+        if occurence == '1' or occurence == '+':
             if parent is None:
                 error.err_add(ctx.errors, pos, 'EXPECTED_KEYWORD',
                               util.keyword_to_str(keywd))
@@ -687,22 +687,22 @@ def _match_stmt(ctx, stmt, specs, canonical):
     (spec, canspec) = specs
     i = 0
     while i < len(spec):
-        (keywd, occurance) = spec[i]
+        keywd, occurence = spec[i]
         if keywd == '$any':
             return (spec, canspec)
         if keywd == '$1.1':
-            (keywd, occurance) = occurance
+            (keywd, occurence) = occurence
             if (stmt.i_module.i_version == '1' and
                 keywd == stmt.keyword):
                 return None
         if keywd == stmt.keyword:
-            if occurance == '1' or occurance == '?':
+            if occurence == '1' or occurence == '?':
                 # consume this match
                 if canonical:
                     return (spec[i+1:], spec_del_kwd(keywd, canspec))
                 else:
                     return (spec[:i] + spec[i+1:], canspec)
-            if occurance == '+':
+            if occurence == '+':
                 # mark that we have found the one that was needed
                 c = (keywd, '*')
                 if canonical:
@@ -716,7 +716,7 @@ def _match_stmt(ctx, stmt, specs, canonical):
                 else:
                     return (spec, canspec)
         elif keywd == '$choice':
-            cases = occurance
+            cases = occurence
             j = 0
             while j < len(cases):
                 # check if this alternative matches - check for a
@@ -736,7 +736,7 @@ def _match_stmt(ctx, stmt, specs, canonical):
                 ctx.errors = save_errors
                 j += 1
         elif keywd == '$interleave':
-            cspec = occurance
+            cspec = occurence
             match_res = _match_stmt(ctx, stmt, (cspec, cspec), canonical)
             if match_res is not None:
                 # we got a match
@@ -752,8 +752,8 @@ def _match_stmt(ctx, stmt, specs, canonical):
                 return None
         elif keywd == '$cut':
             # any non-optional statements left are errors
-            for keywd, occurance in spec[:i]:
-                if occurance == '1' or occurance == '+':
+            for keywd, occurence in spec[:i]:
+                if occurence == '1' or occurence == '+':
                     error.err_add(ctx.errors, stmt.pos, 'UNEXPECTED_KEYWORD_1',
                                   (util.keyword_to_str(stmt.raw_keyword),
                                    util.keyword_to_str(keywd)))
@@ -761,7 +761,7 @@ def _match_stmt(ctx, stmt, specs, canonical):
             spec = spec[i:]
             i = 0
         elif canonical:
-            if occurance == '1' or occurance == '+':
+            if occurence == '1' or occurence == '+':
                 error.err_add(ctx.errors, stmt.pos,
                               'UNEXPECTED_KEYWORD_CANONICAL_1',
                               (util.keyword_to_str(stmt.raw_keyword),

--- a/pyang/plugins/metadata.py
+++ b/pyang/plugins/metadata.py
@@ -22,14 +22,14 @@ def pyang_plugin_init():
     grammar.register_extension_module(md_module_name)
 
     # Register the special grammar
-    for stmt, occurance, (arg, rules), add_to_stmts in md_stmts:
+    for stmt, occurence, (arg, rules), add_to_stmts in md_stmts:
         grammar.add_stmt((md_module_name, stmt), (arg, rules))
         grammar.add_to_stmts_rules(add_to_stmts,
-                                   [((md_module_name, stmt), occurance)])
+                                   [((md_module_name, stmt), occurence)])
 
 md_stmts = [
 
-    # (<keyword>, <occurance when used>,
+    # (<keyword>, <occurence when used>,
     #  (<argument type name | None>, <substmts>),
     #  <list of keywords where <keyword> can occur>)
 

--- a/pyang/plugins/restconf.py
+++ b/pyang/plugins/restconf.py
@@ -32,10 +32,10 @@ def pyang_plugin_init():
     statements.add_keywords_with_no_explicit_config(yd)
 
     # Register the special grammar
-    for stmt, occurance, (arg, rules), add_to_stmts in restconf_stmts:
+    for stmt, occurence, (arg, rules), add_to_stmts in restconf_stmts:
         grammar.add_stmt((restconf_module_name, stmt), (arg, rules))
         grammar.add_to_stmts_rules(add_to_stmts,
-                                   [((restconf_module_name, stmt), occurance)])
+                                   [((restconf_module_name, stmt), occurence)])
 
     # Add validation functions
     statements.add_validation_fun('expand_2',
@@ -49,7 +49,7 @@ def pyang_plugin_init():
 
 restconf_stmts = [
 
-    # (<keyword>, <occurance when used>,
+    # (<keyword>, <occurence when used>,
     #  (<argument type name | None>, <substmts>),
     #  <list of keywords where <keyword> can occur>)
 

--- a/pyang/plugins/smi.py
+++ b/pyang/plugins/smi.py
@@ -49,10 +49,10 @@ def pyang_plugin_init():
     grammar.register_extension_module(smi_module_name)
 
     # Register the special grammar
-    for stmt, occurance, (arg, rules), add_to_stmts in smi_stmts:
+    for stmt, occurence, (arg, rules), add_to_stmts in smi_stmts:
         grammar.add_stmt((smi_module_name, stmt), (arg, rules))
         grammar.add_to_stmts_rules(add_to_stmts,
-                                   [((smi_module_name, stmt), occurance)])
+                                   [((smi_module_name, stmt), occurence)])
 
     # Add validation step
     statements.add_validation_phase('smi_set_oid', after='inherit_properties')
@@ -71,7 +71,7 @@ def pyang_plugin_init():
 
 smi_stmts = [
 
-    # (<keyword>, <occurance when used>,
+    # (<keyword>, <occurence when used>,
     #  (<argument type name | None>, <substmts>),
     #  <list of keywords where <keyword> can occur>)
 

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -37,7 +37,7 @@ def _sequence(one, two):
 def add_validation_fun(phase, keywords, fun):
     """Add a validation function to some phase in the framework.
 
-    Function `fun` is called for each valid occurance of each keyword in
+    Function `fun` is called for each valid occurence of each keyword in
     `keywords`.
     Can be used by plugins to do special validation of extensions."""
     for keyword in keywords:

--- a/pyang/syntax.py
+++ b/pyang/syntax.py
@@ -29,9 +29,9 @@ length_str = r'((min|max|[0-9]+)\s*' \
              r'(min|max|[0-9]+)\s*)?)'
 length_expr = length_str + r'(\|\s*' + length_str + r')*'
 re_length_part = re.compile(length_str)
-range_str = r'((\-INF|min|max|((\+|\-)?[0-9]+(\.[0-9]+)?))\s*' \
+range_str = r'((min|max|((\+|\-)?[0-9]+(\.[0-9]+)?))\s*' \
             r'(\.\.\s*' \
-            r'(INF|min|max|(\+|\-)?[0-9]+(\.[0-9]+)?)\s*)?)'
+            r'(min|max|(\+|\-)?[0-9]+(\.[0-9]+)?)\s*)?)'
 range_expr = range_str + r'(\|\s*' + range_str + r')*'
 re_range_part = re.compile(range_str)
 

--- a/pyang/types.py
+++ b/pyang/types.py
@@ -41,15 +41,20 @@ class IntTypeSpec(TypeSpec):
         self.max = maximum
 
     def str_to_val(self, errors, pos, string, _module):
+        negative = string.startswith('-')
+        base = 10
+        start = 0
+        if len(string) > negative + 1 and string[negative] == '0':
+            second = string[negative + 1]
+            if second == 'x':
+                base = 16
+                start = 2
+            else:
+                base = 8
+                start = 1
         try:
-            if len(string) > 1 and string[0] == '0' and string[1] != 'x':
-                # positive octal
-                string = string[:1] + 'o' + string[1:]
-            elif len(string) > 2 and string[0] == '-' and \
-                 string[1] == '0' and string[2] != 'x':
-                # negative octal
-                string = string[:2] + 'o' + string[2:]
-            return int(string, 0)
+            absolute = int(string[negative + start:], base)
+            return -absolute if negative else absolute
         except ValueError:
             err_add(errors, pos, 'TYPE_VALUE',
                     (string, self.definition, 'not an integer'))

--- a/test/test_issues/test_i225/test.sh
+++ b/test/test_issues/test_i225/test.sh
@@ -4,21 +4,39 @@ set -e
 # since virtualenv manipulates env vars it is better to keep all
 # the dependent tasks runing inside a single process.
 
+current_dir=$PWD
 ## setup ---------------------------------------------------------------------
 # install virtualenv
+exec 6>&1 7>&2 >.test-env.log 2>&1
+
+setup_failed() {
+    exec >&6 2>&7 6>&- 7>&-
+    echo
+    echo "Virtualenv setup failed, with output:"
+    echo "====================================="
+    cat $current_dir/.test-env.log
+    echo "====================================="
+    echo "Virtual env setup failure output ends"
+    echo
+    exit 1
+}
+trap setup_failed ERR
+
 [ -d .test-env ] || \
-    virtualenv --system-site-packages --always-copy .test-env > /dev/null
+    virtualenv --system-site-packages --always-copy .test-env
 # activate it
 source .test-env/bin/activate
 # Install pytest
-pip install pytest > /dev/null
+pip install pytest
 # Build pyang from source and install it using pip
-current_dir=$PWD
 cd ../../..
 rm -f dist/*.whl
-python setup.py bdist_wheel > /dev/null
-pip install -I dist/*.whl > /dev/null
+python setup.py bdist_wheel
+pip install -I dist/*.whl
 cd $current_dir
+trap - ERR
+exec >&6 2>&7 6>&- 7>&-
+echo "Virtualenv setup succeeded"
 
 ## tests ---------------------------------------------------------------------
 py.test test_*.py
@@ -32,3 +50,4 @@ rm -Rf .test-env
 cd ../../..
 rm -Rf pyang.egg-info .cache build/*.whl
 cd $current_dir
+rm -f .test-env.log

--- a/test/test_issues/test_i225/test.sh
+++ b/test/test_issues/test_i225/test.sh
@@ -31,8 +31,6 @@ pip install pytest
 # Build pyang from source and install it using pip
 cd ../../..
 rm -f dist/*.whl
-pip install -r requirements.txt
-python -c "import lxml.etree"
 python setup.py bdist_wheel
 pip install -I dist/*.whl
 cd $current_dir

--- a/test/test_issues/test_i225/test.sh
+++ b/test/test_issues/test_i225/test.sh
@@ -31,6 +31,8 @@ pip install pytest
 # Build pyang from source and install it using pip
 cd ../../..
 rm -f dist/*.whl
+pip install -r requirements.txt
+python -c "import lxml.etree"
 python setup.py bdist_wheel
 pip install -I dist/*.whl
 cd $current_dir


### PR DESCRIPTION
Rebased previous PR; this time, setup should work without lxml already being installed.

The XSD pattern validation si something I've been originally told was missing in pyang, hence I independently came up with a solution that turned out to be already present. Given that LXML is now a requirement, it can always be used.

I do wonder about whether pyang should list as many errors as possible, (e.g. validate values against valid patterns, even if there was a pattern that was invalid in the type definition).