### PR TITLE
Bugfix #606: A definition of 'current' should not reference a 'deprecated' definition

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -1952,6 +1952,7 @@ def v_reference_list(ctx, stmt):
                 elif ptr is None or ptr.keyword != 'leaf':
                     err_add(ctx.errors, key.pos, 'BAD_KEY', x)
                     return
+                chk_status(ctx, ptr.parent, ptr)
                 type_ = ptr.search_one('type')
                 if stmt.i_module.i_version == '1':
                     if type_ is not None:

--- a/test/test_issues/test_i606/Makefile
+++ b/test/test_issues/test_i606/Makefile
@@ -1,0 +1,4 @@
+test: test1
+
+test1:
+	$(PYANG) mod1.yang --print-error-code 2>&1 | diff expect/mod1.expect -

--- a/test/test_issues/test_i606/expect/mod1.expect
+++ b/test/test_issues/test_i606/expect/mod1.expect
@@ -1,0 +1,2 @@
+mod1.yang:6: error: BAD_STATUS_REFERENCE
+mod1.yang:6: error: BAD_STATUS_REFERENCE

--- a/test/test_issues/test_i606/mod1.yang
+++ b/test/test_issues/test_i606/mod1.yang
@@ -1,0 +1,25 @@
+module mod1 {
+  yang-version 1.1;
+  namespace "urn:mod1";
+  prefix m1;
+
+  list lst {
+    key "name le1 le2";
+    status current;
+
+    leaf name {
+      type string;
+      status obsolete; // error: illegal, since name is obsolete
+    }
+
+    leaf le1 {
+      type string;
+      status deprecated; // error: illegal, since name is deprecated
+    }
+
+    leaf le2 {
+      type string;
+      status current; // no errors
+    }
+  }
+}


### PR DESCRIPTION
Refer to #606 