### PR TITLE
fix the issue of range and length restriction

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -851,7 +851,7 @@ def v_type_type(ctx, stmt):
         err_add(ctx.errors, length.pos, 'BAD_RESTRICTION', 'length')
     elif length is not None:
         stmt.i_is_derived = True
-        lengths_spec = types.validate_length_expr(ctx.errors, length)
+        lengths_spec = types.validate_length_expr(ctx.errors, length, stmt)
         if lengths_spec is not None:
             stmt.i_lengths = lengths_spec[0]
             stmt.i_type_spec = types.LengthTypeSpec(stmt.i_type_spec,


### PR DESCRIPTION
@fredgan and @mbj4668,

Could you please help review my code change for the issue of range and length restriction?

The following is the technical detail.

Thanks 

Jie

Restrictions are mentioned in RFC 7950

> 9.2.3.  Restrictions
>    All integer types can be restricted with the "range" statement
> 
> 9.3.3.  Restrictions
>    A decimal64 type can be restricted with the "range" statement
> 
> 9.4.3.  Restrictions
>    A string can be restricted with the "length" (Section 9.4.4) and   "pattern" (Section 9.4.5) statements.
> 
> 9.4.4.  The "length" Statement
>    The "length" statement, which is an optional substatement to the   "type" statement, takes as an argument a length expression string.   It is used to restrict the built-in types "string" and "binary" or   types derived from them.
> 
> 9.8.1.  Restrictions
>    A binary type can be restricted with the "length" (Section 9.4.4)   statement.  The length of a binary value is the number of octets it   contains.
> 

1. All integer types and decimal64 type can be restricted with the "range" statement
2. binary type and string type can be restricted with the "length" statement.

class RangeTypeSpec is used to validate the restricted range.
class LengthTypeSpec is used to validate the restricted length.

Normally the logic of validating range is almost same as length, but there are some differences between class RangeTypeSpec and class LengthTypeSpec.

1. class RangeTypeSpec has the attributes of min and max
2. class LengthTypeSpec has not attributes of min and max
3. The attribute of base in class RangeTypeSpec is always a object of RangeTypeSpec or IntTypeSpec or Decimal64TypeSpec.
(1) integer types restricted with the " range" statement
(2) decimal64 type restricted with the "range" statement
4. The attribute of base in class LengthTypeSpec is an object of LengthTypeSpec or PatternTypeSpec or StringTypeSpec or BinaryTypeSpec.
(1) string type restricted with the "length" statement
As a string can be restricted with the "length" and "pattern" statements, i_type_spec of type statement can be an object of LengthTypeSpec or PatternTypeSpec.
But the class PatternTypeSpec can’t be used to validate the restricted length, it need to be handled specially.
(2) binary type restricted with the "length" statement

To fix range and length restriction issue, the following is my solution:

1. Introduce the new attributes of min and max in the class StringTypeSpec and BinaryTypeSpec.
 
The following is mentioned in RFC 7950 

> 9.4.4.  The "length" Statement
> A length value is a non-negative integer or one   of the special values "min" or "max".  "min" and "max" mean the   minimum and maximum lengths accepted for the type being restricted,   respectively.  An implementation is not required to support a length   value larger than 18446744073709551615.

The length value is from 0 to 18446744073709551615.

Actually the length value is checked in the function of validate_length_expr.

So I introduce the new attributes of min and max in the class StringTypeSpec and BinaryTypeSpec as the following:
```
class StringTypeSpec(TypeSpec):
    def __init__(self):
        TypeSpec.__init__(self, 'string')
        self.min = 0
        self.max = 18446744073709551615

class BinaryTypeSpec(TypeSpec):
    def __init__(self):
        TypeSpec.__init__(self, 'binary')
        self.min = 0
        self.max = 18446744073709551615
```

2. Introduce the new attributes of min and max in the class LengthTypeSpec same as RangeTypeSpec
3. Enhance the function of validate_length_expr to validate the restricted length as the implementation  validate_range_expr
4. Enhance the method of validate in the class LengthTypeSpec and RangeTypeSpec
In original design the method of validate only support checking a single value, now it can support checking a range value.