### PR TITLE
Output all missing Hello modules, then exit

### DIFF
--- a/bin/pyang
+++ b/bin/pyang
@@ -309,6 +309,7 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
 
     if o.hello:
         ctx.capabilities = hel.registered_capabilities()
+        modules_missing = False
         for mn, rev in hel.yang_modules():
             mod = ctx.search_module(error.Position(''), mn, rev)
             if mod is None:
@@ -317,8 +318,11 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                     emarg += "@" + rev
                 sys.stderr.write(
                     "module '%s' specified in hello not found.\n" % emarg)
-                sys.exit(1)
-            modules.append(mod)
+                modules_missing = True
+            else:
+                modules.append(mod)
+        if modules_missing is True:
+            sys.exit(1)
     else:
         if len(filenames) == 0:
             text = sys.stdin.read()


### PR DESCRIPTION
Useful for informational purposes.

Previous behavior:
```
    "xr/621/capabilities-ncs1k.xml": [
        "module 'Cisco-IOS-XR-sysadmin-instmgr-cfg@2015-08-30' specified in hello not found."
    ],
```

Change behavior:
```
    "xr/621/capabilities-ncs1k.xml": [
        "module 'Cisco-IOS-XR-sysadmin-instmgr-cfg@2015-08-30' specified in hello not found.",
        "module 'ietf-yang-smiv2@2011-11-25' specified in hello not found.",
        "module 'ietf-yang-types@2010-09-24' specified in hello not found.",
        "module 'Cisco-IOS-XR-sysadmin-services@2016-11-10' specified in hello not found.",
        "module 'ietf-inet-types@2010-09-24' specified in hello not found.",
        "module 'Cisco-IOS-XR-sysadmin-nto-misc-set-hostname@2016-10-13' specified in hello not found.",
        "module 'ietf-yang-library@2016-06-21' specified in hello not found.",
        "module 'ENTITY-STATE-TC-MIB@2005-11-22' specified in hello not found."
    ],
```