### PR TITLE
Fix #678 deviate replace regression

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2332,7 +2332,7 @@ def v_reference_deviate(ctx, stmt):
                 del t.substmts[idx]
                 if (c.keyword == 'type'
                     and c.i_typedef is not None
-                    and ':' in c.arg
+                    and ':' not in c.arg
                     and t.i_module.i_prefix != c.i_module.i_prefix):
 
                     c.arg = c.i_module.i_prefix + ':' + c.arg

--- a/test/test_issues/test_i678/Makefile
+++ b/test/test_issues/test_i678/Makefile
@@ -1,0 +1,3 @@
+test:
+	$(PYANG) -f yang deviate-test.yang 2>&1 | diff - expect.yang
+

--- a/test/test_issues/test_i678/deviate-test.yang
+++ b/test/test_issues/test_i678/deviate-test.yang
@@ -1,0 +1,17 @@
+module deviate-test {
+  namespace "urn:deviate-test";
+  prefix deviate-test;
+
+  import target {
+    prefix target;
+  }
+  import types {
+    prefix types;
+  }
+
+  deviation "/target:data/target:original" {
+    deviate replace {
+      type types:replacement-test-type;
+    }
+  }
+}

--- a/test/test_issues/test_i678/expect.yang
+++ b/test/test_issues/test_i678/expect.yang
@@ -1,0 +1,17 @@
+module deviate-test {
+  namespace "urn:deviate-test";
+  prefix deviate-test;
+
+  import target {
+    prefix target;
+  }
+  import types {
+    prefix types;
+  }
+
+  deviation "/target:data/target:original" {
+    deviate replace {
+      type types:replacement-test-type;
+    }
+  }
+}

--- a/test/test_issues/test_i678/target.yang
+++ b/test/test_issues/test_i678/target.yang
@@ -1,0 +1,14 @@
+module target {
+  namespace "urn:target";
+  prefix target;
+
+  typedef test-type {
+    type string;
+  }
+
+  container data {
+    leaf original {
+      type target:test-type;
+    }
+  }
+}

--- a/test/test_issues/test_i678/types.yang
+++ b/test/test_issues/test_i678/types.yang
@@ -1,0 +1,8 @@
+module types {
+  namespace "urn:types";
+  prefix types;
+
+  typedef replacement-test-type {
+    type string;
+  }
+}


### PR DESCRIPTION
Fix the issue described in #678 

This is a regression introduced in release 2.2.0 with commit

**Code improvements for idiomatic python style** 
https://github.com/mbj4668/pyang/commit/b7c7683e0222ea597b58da9e118c8fe3ccc20070#diff-037294d92fe20ee53b92ebe8ae6ad7deR2184

The issue was the change from 
```
 and c.arg.find(":") == -1
```
to 
```
and ':' in c.arg
```

The original logic checked that ```:``` was not found in the arg. Fix the issue by adding a ```not```
```
and ':' not in c.arg
```

This commit also adds a test case to reproduce the issue and verify the fix.