### PR TITLE
Removed xpath_parser.py from the excluded list in setup.cfg so it can…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,4 @@ select =
 
 # Generated files
 exclude =
-	pyang/xpath_parsetab.py,
-	pyang/xpath_parser.py
+	pyang/xpath_parsetab.py


### PR DESCRIPTION
The pyang/xpath_parser.py is needed for as, so we are able to build up yang models from existing one.