### PR TITLE
Fix sample-xml-skeleton unknown namespace crash

### DIFF
--- a/pyang/plugins/sample-xml-skeleton.py
+++ b/pyang/plugins/sample-xml-skeleton.py
@@ -113,6 +113,11 @@ class SampleXMLSkeletonPlugin(plugin.PyangPlugin):
         for yam in modules:
             if yam.keyword == 'module':
                 self.ns_uri[yam] = yam.search_one("namespace").arg
+                for imp in yam.search('import'):
+                    iyam = ctx.get_module(imp.arg)
+                    if iyam:
+                        self.ns_uri[iyam] = iyam.search_one("namespace").arg
+
         self.top = etree.Element(
             self.doctype,
             {"xmlns": "urn:ietf:params:xml:ns:netconf:base:1.0"})
@@ -216,7 +221,7 @@ class SampleXMLSkeletonPlugin(plugin.PyangPlugin):
         res = etree.SubElement(parent, node.arg)
         mm = node.main_module()
         if mm != module:
-            res.attrib["xmlns"] = self.ns_uri[mm]
+            res.attrib["xmlns"] = self.ns_uri.get(mm, "urn:UNKNOWN")
             module = mm
         return res, module, path
 

--- a/test/test_issues/test_i683/base.yang
+++ b/test/test_issues/test_i683/base.yang
@@ -1,0 +1,8 @@
+module base {
+  yang-version 1.1;
+  namespace "urn:base";
+  prefix base;
+
+  container c {
+  }
+}

--- a/test/test_issues/test_i683/ext.yang
+++ b/test/test_issues/test_i683/ext.yang
@@ -1,0 +1,14 @@
+module ext {
+  yang-version 1.1;
+  namespace "urn:ext";
+  prefix ext;
+
+  import base {
+    prefix base;
+  }
+
+  augment "/base:c" {
+    container b {
+    }
+  }
+}

--- a/test/test_issues/test_i683/main.expect
+++ b/test/test_issues/test_i683/main.expect
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <c xmlns="urn:base">
+    <b xmlns="urn:ext">
+      <a xmlns="urn:main"/>
+    </b>
+  </c>
+</data>

--- a/test/test_issues/test_i683/main.yang
+++ b/test/test_issues/test_i683/main.yang
@@ -1,0 +1,18 @@
+module main {
+  yang-version 1.1;
+  namespace "urn:main";
+  prefix main;
+
+  import base {
+    prefix base;
+  }
+
+  import ext {
+    prefix ext;
+  }
+
+  augment "/base:c/ext:b" {
+    container a {
+    }
+  }
+}

--- a/test/test_issues/test_i683/makefile
+++ b/test/test_issues/test_i683/makefile
@@ -1,0 +1,4 @@
+test: test1
+
+test1:
+	-$(PYANG) --format=sample-xml-skeleton base.yang main.yang 2>&1 | diff main.expect -


### PR DESCRIPTION
The sample-xml-skeleton format can crash when generating XML for an imported module that isn't explicitly listed on the command line.

This PR fixes the problem by automatically adding namespaces for imported modules. It also avoids a crash should any namespaces still (for some reason) not be known.

I'll update the PR with a test.