### PR TITLE
Fix#690 import circular dependency error

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -1491,7 +1491,7 @@ def v_expand_1_uses(ctx, stmt):
     if getattr(stmt, 'is_grammatically_valid', None) is False:
         return
 
-    if stmt.i_grouping is None:
+    if not hasattr(stmt, 'i_grouping') or stmt.i_grouping is None:
         return
 
     # possibly expand any uses within the grouping

--- a/test/test_issues/test_i690/Makefile
+++ b/test/test_issues/test_i690/Makefile
@@ -1,0 +1,4 @@
+test: test1
+
+test1:
+	-$(PYANG) test.yang --print-error-code 2>&1 | diff main.expect -

--- a/test/test_issues/test_i690/main.expect
+++ b/test/test_issues/test_i690/main.expect
@@ -1,0 +1,1 @@
+test2.yang:9: error: CIRCULAR_DEPENDENCY

--- a/test/test_issues/test_i690/test.yang
+++ b/test/test_issues/test_i690/test.yang
@@ -1,0 +1,32 @@
+module test {
+
+  yang-version "1";
+
+  namespace "http://test";
+
+  prefix test;
+
+  import test2 {
+    prefix test2;
+  }
+
+
+  organization "x";
+  contact "x";
+  description "x";
+
+  revision 2017-04-21 {
+    description "1st revision.";
+  }
+
+  grouping testgrouping1 {
+   leaf test {
+    type string;
+   }
+  }
+  grouping testgrouping {
+    uses testgrouping1;
+  }
+
+  uses test2:testgrouping;
+}

--- a/test/test_issues/test_i690/test2.yang
+++ b/test/test_issues/test_i690/test2.yang
@@ -1,0 +1,29 @@
+module test2 {
+
+  yang-version "1";
+
+  namespace "http://test2";
+
+  prefix test2;
+
+  import test {
+    prefix test;
+  }
+
+  organization "x";
+  contact "x";
+  description "x";
+
+  revision 2017-04-21 {
+    description "1st revision.";
+  }
+
+  container one {
+    leaf two {
+      type string;
+    }
+  }
+  grouping testgrouping {
+    uses test:testgrouping;
+  }
+}


### PR DESCRIPTION
1 Allow module circular import error to print explicitly.
2 If any module circular import error exists, stop the further uses expanding.

Hi @mbj4668 , this need you to review. I am not quite sure the solution is good. Or maybe something is left out by me.