### PR TITLE
Pyang plugin for checking 3GPP style for YANG modules

### DIFF
--- a/pyang/plugins/threegpp.py
+++ b/pyang/plugins/threegpp.py
@@ -1,0 +1,247 @@
+"""3GPP usage guidelines plugin
+See 3GPP TS 32.160 clause 6.2
+
+Copyright Ericsson 2020
+Author balazs.lengyel@ericsson.com
+Revision 2020-11-10
+"""
+
+import optparse
+import re
+import io
+import sys
+
+from pyang import plugin
+from pyang import statements
+from pyang import error
+from pyang.error import err_add
+from pyang.plugins import lint
+
+def pyang_plugin_init():
+    plugin.register_plugin(THREEGPPlugin())
+
+class THREEGPPlugin(lint.LintPlugin):
+    def __init__(self):
+        lint.LintPlugin.__init__(self)
+        self.modulename_prefixes = ['_3gpp']
+
+    def add_opts(self, optparser):
+        optlist = [
+            optparse.make_option("--3gpp",
+                                 dest="threegpp",
+                                 action="store_true",
+                                 help="Validate the module(s) according to " \
+                                 "3GPP rules."),
+            ]
+        optparser.add_options(optlist)
+
+    def setup_ctx(self, ctx):
+        if not ctx.opts.threegpp:
+            return
+        self._setup_ctx(ctx)
+
+        error.add_error_code(
+           '3GPP_BAD_NAMESPACE_VALUE', 3,
+           '3GPP: the namespace should be on the form '
+           'urn:3gpp:sa5:%s')
+
+        statements.add_validation_fun(
+            'grammar', ['namespace'],
+            lambda ctx, s: self.v_chk_namespace(ctx, s))
+
+        error.add_error_code(
+           '3GPP_BAD_PREFIX_VALUE', 3,
+           '3GPP: the prefix should end with 3gpp')
+
+        error.add_error_code(
+           '3GPP_TOO_LONG_PREFIX', 3,
+           '3GPP: the prefix should not be longer than 10 characters')
+
+        statements.add_validation_fun(
+            'grammar', ['prefix'],
+            lambda ctx, s: self.v_chk_prefix(ctx, s))
+
+        error.add_error_code(
+           '3GPP_BAD_YANG_VERSION', 3,
+           '3GPP: the yang-version should be 1.1')
+
+        statements.add_validation_fun(
+            'grammar', ['yang-version'],
+            lambda ctx, s: self.v_chk_yang_version(ctx, s))
+
+        # check that yang-version is present. If not,
+        #  it defaults to 1. which is bad for 3GPP
+        statements.add_validation_fun(
+            'grammar', ['module'],
+            lambda ctx, s: self.v_chk_yang_version_present(ctx, s))
+
+        error.add_error_code(
+           '3GPP_STATEMENT_NOT_ALLOWED', 3,
+           ('3GPP: YANG statements anydata, anyxml, deviation, rpc '
+            'should not be used'))
+
+        error.add_error_code(
+           '3GPP_LIMITED_CONTAINER_USE', 4,
+           ('3GPP: containers should only be used to contain the attributes '
+            'of a class'))
+
+        statements.add_validation_fun(
+            'grammar', ['anydata' , 'anyxml' , 'deviation' , 'rpc'],
+            lambda ctx, s: self.v_chk_not_allowed_statements(ctx, s))
+
+        statements.add_validation_fun(
+            'grammar', ['container'],
+            lambda ctx, s: self.v_chk_limited_container_use(ctx, s))
+
+        error.add_error_code(
+           '3GPP_BAD_CONTACT', 3,
+           '3GPP: incorrect contact statement')
+
+        statements.add_validation_fun(
+            'grammar', ['contact'],
+            lambda ctx, s: self.v_chk_contact(ctx, s))
+
+        error.add_error_code(
+           '3GPP_BAD_ORGANIZATION', 3,
+           '3GPP: incorrect organization statement')
+
+        statements.add_validation_fun(
+            'grammar', ['organization'],
+            lambda ctx, s: self.v_chk_organization(ctx, s))
+
+        error.add_error_code(
+           '3GPP_MISSING_MODULE_REFERENCE', 3,
+           '3GPP: the module should have a reference substatement')
+
+
+    def pre_validate_ctx(self, ctx, modules):
+        if ctx.opts.threegpp:
+            ctx.canonical = False
+        return
+
+    def v_chk_organization(self, ctx, stmt):
+        r = '3GPP'
+        if re.search(r, stmt.arg, re.IGNORECASE) is None:
+            err_add(ctx.errors, stmt.pos, '3GPP_BAD_ORGANIZATION',())
+
+    def v_chk_contact(self, ctx, stmt):
+        if stmt.arg != ('https://www.3gpp.org/DynaReport/'
+                        'TSG-WG--S5--officials.htm?Itemid=464'):
+            err_add(ctx.errors, stmt.pos, '3GPP_BAD_CONTACT',())
+
+    def v_chk_not_allowed_statements(self, ctx, stmt):
+        err_add(ctx.errors, stmt.pos, '3GPP_STATEMENT_NOT_ALLOWED',())
+
+    def v_chk_limited_container_use(self, ctx, stmt):
+        if stmt.arg  != 'attributes' or stmt.parent.keyword != 'list' :
+            err_add(ctx.errors, stmt.pos, '3GPP_LIMITED_CONTAINER_USE',())
+
+    def v_chk_yang_version(self, ctx, stmt):
+        r = '1.1'
+        if re.match(r, stmt.arg) is None:
+            err_add(ctx.errors, stmt.pos, '3GPP_BAD_YANG_VERSION',())
+
+    def v_chk_yang_version_present(self, ctx, stmt):
+        yang_version_present = False
+        for stmt in stmt.substmts:
+            if stmt.keyword == 'yang-version' :
+                yang_version_present = True
+        if yang_version_present == False :
+            err_add(ctx.errors, stmt.pos, '3GPP_BAD_YANG_VERSION',())
+
+    def v_chk_namespace(self, ctx, stmt):
+        r = 'urn:3gpp:sa5:' + stmt.i_module.arg +'$'
+        if re.match(r, stmt.arg) is None:
+            err_add(ctx.errors, stmt.pos, '3GPP_BAD_NAMESPACE_VALUE',
+                    stmt.i_module.arg)
+
+    def v_chk_prefix(self, ctx, stmt):
+        if stmt.parent.keyword != 'module' :
+            return
+        r = '.+3gpp$'
+        if re.match(r, stmt.arg) is None:
+            err_add(ctx.errors, stmt.pos, '3GPP_BAD_PREFIX_VALUE',())
+        if len(stmt.arg) > 10   :
+            err_add(ctx.errors, stmt.pos, '3GPP_TOO_LONG_PREFIX',())
+
+    def post_validate_ctx(self, ctx, modules):
+        if not ctx.opts.threegpp:
+            return
+        """Remove some lint errors that 3GPP considers acceptable"""
+        for ctx_error in ctx.errors[:]:
+            if ((ctx_error[1] == "LINT_MISSING_REQUIRED_SUBSTMT"
+                    or ctx_error[1] == "LINT_MISSING_RECOMMENDED_SUBSTMT")
+                and ctx_error[2][2] == 'description'
+                and (ctx_error[2][1] == 'enum'
+                    or  ctx_error[2][1] == 'bit'
+                    or  ctx_error[2][1] == 'choice'
+                    or  ctx_error[2][1] == 'container'
+                    or  ctx_error[2][1] == 'leaf-list'
+                    or  ctx_error[2][1] == 'leaf'
+                    or  ctx_error[2][1] == 'typedef'
+                    or  ctx_error[2][1] == 'grouping'
+                    or  ctx_error[2][1] == 'augment')):
+                # remove error from ctx
+                ctx.errors.remove(ctx_error)
+
+        # check 3gpp format:
+        error.add_error_code(
+           '3GPP_TAB_IN_FILE', 3,
+           '3GPP: tab characters should not be used in YANG modules')
+
+        error.add_error_code(
+           '3GPP_WHITESPACE_AT_END_OF_LINE', 3,
+           '3GPP: extra whitespace should not be added at the end of the line')
+
+        error.add_error_code(
+           '3GPP_LONG_LINE', 3,
+           '3GPP: line longer than 80 characters')
+
+        error.add_error_code(
+           '3GPP_CR_IN_FILE', 3,
+           ('3GPP: Carriage-return characters should not be used. '
+            'End-of-line should be just one LF character'))
+
+        error.add_error_code(
+           '3GPP_NON_ASCII', 4,
+           '3GPP: the module should only use ASCII characters')
+
+        for module in modules:
+            filename = module.pos.ref
+            try:
+                fd = io.open(filename, "r", encoding="utf-8", newline='')
+                lineno = 0
+                for line in fd:
+                    lineno += 1
+                    self.pos = error.Position(module.pos.ref)
+                    self.pos.line = lineno
+                    #  no tabs
+                    if (line.find('\t') != -1 ):
+                        err_add(ctx.errors, self.pos, '3GPP_TAB_IN_FILE',())
+                    #  no whitespace after the line
+                    #  removed for now as there are just too many of these
+                    #    errors
+                    # if (re.search('.*\s+\n',line) != None ):
+                    #    err_add(ctx.errors, self.pos,
+                    #        '3GPP_WHITESPACE_AT_END_OF_LINE',())
+                    #  lines shorter then 80 char
+                    if (len(line) > 82 ):
+                        err_add(ctx.errors, self.pos, '3GPP_LONG_LINE',())
+                    #  EOL should be just NL no CR
+                    if (line.find('\r') != -1 ):
+                        err_add(ctx.errors, self.pos, '3GPP_CR_IN_FILE',())
+                    #  only us-ascii chars
+                    try:
+                        line.encode('ascii')
+                    except UnicodeEncodeError:
+                        err_add(ctx.errors, self.pos, '3GPP_NON_ASCII',())
+
+            except IOError as ex:
+                sys.stderr.write("error %s: %s\n" % (filename, ex))
+                sys.exit(1)
+            except UnicodeDecodeError as ex:
+                s = str(ex).replace('utf-8', 'utf8')
+                sys.stderr.write("%s: unicode error: %s\n" % (filename, s))
+                sys.exit(1)
+
+        return

--- a/pyang/plugins/threegpp.py
+++ b/pyang/plugins/threegpp.py
@@ -4,6 +4,30 @@ See 3GPP TS 32.160 clause 6.2
 Copyright Ericsson 2020
 Author balazs.lengyel@ericsson.com
 Revision 2020-11-10
+
+Checks implemented
+6.2.1.2     Module name starts with _3gpp-
+6.2.1.3     namespace pattern urn:3gpp:sa5:<module-name>
+6.2.1.4-a   prefix ends with 3gpp
+6.2.1.4-b   prefix.length <= 10 char
+6.2.1.5     yang 1.1
+6.2.1.6-a   anydata
+6.2.1.6-b   anyxml
+6.2.1.6-c   rpc
+6.2.1.6-d   deviation
+6.2.1.b-a   module-description
+6.2.1.b-b   module-organization
+6.2.1.b-c   module-organization includes 3gpp
+6.2.1.b-d   module-contact
+6.2.1.c     module-reference
+6.2.1.d-a   module-revision
+6.2.1.d-a   module-revision-reference
+6.2.1.e     default meaning
+6.2.1.f-a   linelength
+6.2.1.f-b   no-tabs
+6.2.1.f-c   no-strange-chars
+6.2.1.f-d   no-CR-chars
+6.2-a       no-containers
 """
 
 import optparse

--- a/test/plugins/test_threegpp/Makefile
+++ b/test/plugins/test_threegpp/Makefile
@@ -1,0 +1,22 @@
+test: test1 test2 test3 test4 test5
+
+test1:
+	# Baseline test that a module following 3gpp guidelines is OK
+	# $(PYANG) --3gpp _3gpp-correct.yang &> correct-3gpp.result
+	$(PYANG) --3gpp _3gpp-correct.yang 
+
+test2:
+	# $(PYANG) --3gpp _3gpp-incorrect.yang &> incorrect-3gpp.result
+	$(PYANG) --3gpp _3gpp-incorrect.yang |& diff incorrect-3gpp.expect -
+
+test3:
+	# $(PYANG) --3gpp _3gpp-missing-incorrect2.yang &> missing-incorrect2-3gpp.result
+	$(PYANG) --3gpp _3gpp-missing-incorrect2.yang |& diff missing-incorrect2-3gpp.expect -
+
+test4:
+	# $(PYANG) --3gpp twogpp-wrongFileName.yang &> twogpp-wrongFileName.result
+	$(PYANG) --3gpp twogpp-wrongFileName.yang |& diff twogpp-wrongFileName.expect -
+
+test5:
+  # Check that normal validation still works
+	$(PYANG) --ietf ietf-yang-types@2013-07-15.yang

--- a/test/plugins/test_threegpp/_3gpp-correct.yang
+++ b/test/plugins/test_threegpp/_3gpp-correct.yang
@@ -1,0 +1,45 @@
+module _3gpp-correct {
+  yang-version 1.1;
+  namespace "urn:3gpp:sa5:_3gpp-correct";
+  prefix cor3gpp;
+
+  organization "3GPP SA5";
+  contact "https://www.3gpp.org/DynaReport/TSG-WG--S5--officials.htm?Itemid=464";
+  description "Correct version of the threegpp pyang plugin test file";
+  reference "3GPP TS 28.623";
+  
+  revision 2020-08-06 { reference "CR-0102"; }  
+
+  list main {
+    config false;
+    status deprecated;
+    description "First Managed Object";
+    leaf a { type uint8; }  }
+}
+
+/*
+Checks passed
+6.2.1.2     Module name starts with _3gpp-
+6.2.1.3     namespace pattern urn:3gpp:saX:<module-name>
+6.2.1.4-a   prefix ends with 3gpp 
+6.2.1.4-b   prefix.length <= 10 char 
+6.2.1.5     yang 1.1
+6.2.1.6-a   anydata
+6.2.1.6-b   anyxml
+6.2.1.6-c   rpc
+6.2.1.6-d   deviation
+6.2.1.b-a   module-description
+6.2.1.b-b   module-organization 
+6.2.1.b-c   module-organization includes 3gpp
+6.2.1.b-d   module-contact
+6.2.1.c     module-reference
+6.2.1.d-a   module-revision
+6.2.1.d-a   module-revision-reference
+6.2.1.e     default meaning
+6.2.1.f-a   linelength
+6.2.1.f-b   no-tabs
+6.2.1.f-c   no-strange-chars
+6.2.1.f-d   no-CR-chars
+6.2-a       no-containers
+
+*/

--- a/test/plugins/test_threegpp/_3gpp-incorrect.yang
+++ b/test/plugins/test_threegpp/_3gpp-incorrect.yang
@@ -1,0 +1,39 @@
+module _3gpp-incorrect {
+  yang-version 1;
+  namespace "urn:3gpp:sa5:_3gpp-xcorrect";
+  prefix corasdfgrty3gp;
+  
+  import _3gpp-correct { prefix xx; }
+
+  organization "2GPP SA5";
+  contact "https://www.3gpp.org/DynaReport/";    
+  reference "XXTS 28.623";
+
+  revision 2020-08-06 { description "whatever"; }  
+
+  container main {
+    config true;
+    status current;
+    anyxml ax {
+      mandatory false;
+    }
+    anydata ad;
+  }
+  
+  rpc do-something { description "text����������������"; }
+  
+  deviation /main/ad {
+    deviate replace {
+      config false;
+    }
+  }
+  
+  list myOBj {
+    key id; 
+    min-elements 0;
+    max-elements unbounded;
+    ordered-by system;
+    
+    leaf id { type string; }
+  }
+}

--- a/test/plugins/test_threegpp/_3gpp-missing-incorrect2.yang
+++ b/test/plugins/test_threegpp/_3gpp-missing-incorrect2.yang
@@ -1,0 +1,6 @@
+module _3gpp-missing-incorrect2 {
+  namespace "urn:4gpp:sa5:_3gpp-missing-incorrect2";
+  prefix xx;
+
+  
+}

--- a/test/plugins/test_threegpp/ietf-yang-types@2013-07-15.yang
+++ b/test/plugins/test_threegpp/ietf-yang-types@2013-07-15.yang
@@ -1,0 +1,480 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+
+
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+
+
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/test/plugins/test_threegpp/incorrect-3gpp.expect
+++ b/test/plugins/test_threegpp/incorrect-3gpp.expect
@@ -1,0 +1,22 @@
+_3gpp-incorrect.yang:1: error: RFC 8407: 4.8: statement "module" must have a "description" substatement
+_3gpp-incorrect.yang:2: error: 3GPP: the yang-version should be 1.1
+_3gpp-incorrect.yang:3: error: 3GPP: the namespace should be on the form urn:3gpp:sa5:_3gpp-incorrect
+_3gpp-incorrect.yang:4: error: 3GPP: the prefix should end with 3gpp
+_3gpp-incorrect.yang:4: error: 3GPP: the prefix should not be longer than 10 characters
+_3gpp-incorrect.yang:6: warning: imported module "_3gpp-correct" not used
+_3gpp-incorrect.yang:8: error: 3GPP: incorrect organization statement
+_3gpp-incorrect.yang:9: error: 3GPP: incorrect contact statement
+_3gpp-incorrect.yang:12: error: RFC 8407: 4.8: statement "revision" must have a "reference" substatement
+_3gpp-incorrect.yang:14: warning: 3GPP: containers should only be used to contain the attributes of a class
+_3gpp-incorrect.yang:15: warning: RFC 8407: 4.4: statement "config" is given with its default value "true"
+_3gpp-incorrect.yang:16: warning: RFC 8407: 4.4: statement "status" is given with its default value "current"
+_3gpp-incorrect.yang:17: error: 3GPP: YANG statements anydata, anyxml, deviation, rpc should not be used
+_3gpp-incorrect.yang:17: error: RFC 8407: 4.14: statement "anyxml" must have a "description" substatement
+_3gpp-incorrect.yang:18: warning: RFC 8407: 4.4: statement "mandatory" is given with its default value "false"
+_3gpp-incorrect.yang:20: error: unexpected keyword "anydata"
+_3gpp-incorrect.yang:23: error: 3GPP: YANG statements anydata, anyxml, deviation, rpc should not be used
+_3gpp-incorrect.yang:23: warning: 3GPP: the module should only use ASCII characters
+_3gpp-incorrect.yang:25: error: 3GPP: YANG statements anydata, anyxml, deviation, rpc should not be used
+_3gpp-incorrect.yang:31: error: RFC 8407: 4.14: statement "list" must have a "description" substatement
+_3gpp-incorrect.yang:33: warning: RFC 8407: 4.4: statement "min-elements" is given with its default value "0"
+_3gpp-incorrect.yang:34: warning: RFC 8407: 4.4: statement "max-elements" is given with its default value "unbounded"

--- a/test/plugins/test_threegpp/missing-incorrect2-3gpp.expect
+++ b/test/plugins/test_threegpp/missing-incorrect2-3gpp.expect
@@ -1,0 +1,13 @@
+_3gpp-missing-incorrect2.yang:1: error: RFC 8407: 4.8: statement "module" must have a "contact" substatement
+_3gpp-missing-incorrect2.yang:1: error: RFC 8407: 4.8: statement "module" must have a "organization" substatement
+_3gpp-missing-incorrect2.yang:1: error: RFC 8407: 4.8: statement "module" must have a "description" substatement
+_3gpp-missing-incorrect2.yang:1: error: RFC 8407: 4.8: statement "module" must have a "revision" substatement
+_3gpp-missing-incorrect2.yang:1: error: 3GPP: Carriage-return characters should not be used. End-of-line should be just one LF character
+_3gpp-missing-incorrect2.yang:2: error: 3GPP: the namespace should be on the form urn:3gpp:sa5:_3gpp-missing-incorrect2
+_3gpp-missing-incorrect2.yang:2: error: 3GPP: Carriage-return characters should not be used. End-of-line should be just one LF character
+_3gpp-missing-incorrect2.yang:3: error: 3GPP: the yang-version should be 1.1
+_3gpp-missing-incorrect2.yang:3: error: 3GPP: the prefix should end with 3gpp
+_3gpp-missing-incorrect2.yang:3: error: 3GPP: Carriage-return characters should not be used. End-of-line should be just one LF character
+_3gpp-missing-incorrect2.yang:4: error: 3GPP: Carriage-return characters should not be used. End-of-line should be just one LF character
+_3gpp-missing-incorrect2.yang:5: error: 3GPP: Carriage-return characters should not be used. End-of-line should be just one LF character
+_3gpp-missing-incorrect2.yang:6: error: 3GPP: Carriage-return characters should not be used. End-of-line should be just one LF character

--- a/test/plugins/test_threegpp/twogpp-wrongFileName.expect
+++ b/test/plugins/test_threegpp/twogpp-wrongFileName.expect
@@ -1,0 +1,9 @@
+twogpp-wrongFileName.yang:1: warning: RFC 8407: 4.1: the module name should start with the string "_3gpp-"
+twogpp-wrongFileName.yang:1: error: RFC 8407: 4.8: statement "module" must have a "contact" substatement
+twogpp-wrongFileName.yang:1: error: RFC 8407: 4.8: statement "module" must have a "organization" substatement
+twogpp-wrongFileName.yang:1: error: RFC 8407: 4.8: statement "module" must have a "description" substatement
+twogpp-wrongFileName.yang:1: error: RFC 8407: 4.8: statement "module" must have a "revision" substatement
+twogpp-wrongFileName.yang:2: error: 3GPP: the namespace should be on the form urn:3gpp:sa5:twogpp-wrongFileName
+twogpp-wrongFileName.yang:3: error: 3GPP: the prefix should end with 3gpp
+twogpp-wrongFileName.yang:5: error: 3GPP: the yang-version should be 1.1
+twogpp-wrongFileName.yang:5: warning: 3GPP: containers should only be used to contain the attributes of a class

--- a/test/plugins/test_threegpp/twogpp-wrongFileName.yang
+++ b/test/plugins/test_threegpp/twogpp-wrongFileName.yang
@@ -1,0 +1,9 @@
+module twogpp-wrongFileName {
+  namespace "urn:twogpp-wrongFileName";
+  prefix tgpp;
+
+  container a {
+    leaf b { type string ; }
+  }
+}
+                             


### PR DESCRIPTION
The provided plugin checks that a YANG module follows the 3gpp YANG style as documented in 3GPP TS 32.160.
It can be invoked with the --3gpp command line option