### PR TITLE
Avoid crash updating bad revision module without yang-version stmt

### DIFF
--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -812,10 +812,13 @@ chk_type_func = \
 
 
 def verrcode(basecode, stmt):
-    if stmt.i_module.i_version == '1':
+    try:
+        if stmt.i_module.i_version == '1':
+            return basecode
+        else:
+            return basecode + '_v' + stmt.i_module.i_version
+    except AttributeError:
         return basecode
-    else:
-        return basecode + '_v' + stmt.i_module.i_version
 
 def err_def_added(new, ctx):
     new_arg = new.arg

--- a/test/test_update/Makefile
+++ b/test/test_update/Makefile
@@ -1,6 +1,6 @@
 PYANG := $(PYANG) --print-error-code --check-update-from
 
-MODULES = a c f h i j
+MODULES = a c f h i j k
 DEVIATION_MODULES = d e
 
 test:

--- a/test/test_update/expect/k.out
+++ b/test/test_update/expect/k.out
@@ -1,0 +1,2 @@
+k@2014-04-01.yang:1: warning: WBAD_REVISION
+k@2014-04-01.yang:1: error: CHK_BAD_REVISION

--- a/test/test_update/k.yang
+++ b/test/test_update/k.yang
@@ -1,0 +1,6 @@
+module k {
+  namespace urn:k;
+  prefix k;
+
+  revision 2014-03-01;
+}

--- a/test/test_update/k@2014-04-01.yang
+++ b/test/test_update/k@2014-04-01.yang
@@ -1,0 +1,6 @@
+module k {
+  namespace urn:k;
+  prefix k;
+
+  revision 2014-03-01;
+}


### PR DESCRIPTION
If yang-version is not present in the module and the revision is bad
when updating, the following crash occurs since `stmt.i_module`
has no  `i_versions` attribute.

```
pyang --print-error-code --check-update-from k.yang k@2014-04-01.yang 
Traceback (most recent call last):
  File "/home/avtobiff/src/github/avtobiff/pyang/bin/pyang", line 545, in <module>
    run()
  File "/home/avtobiff/src/github/avtobiff/pyang/bin/pyang", line 445, in run
    p.post_validate_ctx(ctx, modules)
  File "/home/avtobiff/src/github/avtobiff/pyang/pyang/plugins/check_update.py", line 165, in post_validate_ctx
    check_update(ctx, modules[0])
  File "/home/avtobiff/src/github/avtobiff/pyang/pyang/plugins/check_update.py", line 218, in check_update
    chk_module(ctx, oldmod, newmod)
  File "/home/avtobiff/src/github/avtobiff/pyang/pyang/plugins/check_update.py", line 227, in chk_module
    chk_revision(oldmod, newmod, ctx)
  File "/home/avtobiff/src/github/avtobiff/pyang/pyang/plugins/check_update.py", line 273, in chk_revision
    errcode = verrcode('CHK_BAD_REVISION', newmod)
  File "/home/avtobiff/src/github/avtobiff/pyang/pyang/plugins/check_update.py", line 815, in verrcode
    if stmt.i_module.i_version == '1':
AttributeError: 'NoneType' object has no attribute 'i_version'
```

This commit just catches the exception and `return basecode`.