### PR TITLE
Fix crash in --check-update-from when revisions are identical.

### DIFF
--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -812,10 +812,10 @@ chk_type_func = \
 
 
 def verrcode(basecode, stmt):
-    if stmt.i_module.i_version == '1':
+    if stmt.i_version == '1':
         return basecode
     else:
-        return basecode + '_v' + stmt.i_module.i_version
+        return basecode + '_v' + stmt.i_version
 
 def err_def_added(new, ctx):
     new_arg = new.arg


### PR DESCRIPTION
Pyang aborts when providing identical files to the --check-update-from option:
```
$ pyang ietf-netconf-acm.yang --check-update-from ietf-netconf-acm.yang
Traceback (most recent call last):
  File "/home/user/local/pyang/bin/pyang", line 545, in <module>
    run()
  File "/home/user/local/pyang/bin/pyang", line 445, in run
    p.post_validate_ctx(ctx, modules)
  File "/home/user/local/pyang/pyang/plugins/check_update.py", line 165, in post_validate_ctx
    check_update(ctx, modules[0])
  File "/home/user/local/pyang/pyang/plugins/check_update.py", line 218, in check_update
    chk_module(ctx, oldmod, newmod)
  File "/home/user/local/pyang/pyang/plugins/check_update.py", line 227, in chk_module
    chk_revision(oldmod, newmod, ctx)
  File "/home/user/local/pyang/pyang/plugins/check_update.py", line 273, in chk_revision
    errcode = verrcode('CHK_BAD_REVISION', newmod)
  File "/home/user/local/pyang/pyang/plugins/check_update.py", line 815, in verrcode
    if stmt.i_module.i_version == '1':
AttributeError: 'NoneType' object has no attribute 'i_version'
```
This pull request is an attempt to fix that.