### PR TITLE
Bugfix #760: augment stmt expanding cause line end comment no printing

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -2977,7 +2977,10 @@ class Statement(object):
         """pointer to the top-level Statement"""
 
         self.parent = parent
-        """pointer to the parent Statement"""
+        """pointer to the parent Statement, maybe on semantics"""
+
+        self.stmt_parent = parent
+        """pointer to the parent Statement, just on statement"""
 
         self.pos = copy.copy(pos)
         """position in input stream, for error reporting"""

--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -154,8 +154,8 @@ def make_link_list(ctx, stmt, link_list):
 
 def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
               indent, indentstep, link_list):
-    # line end comment has been printed
     if is_line_end_comment(stmt):
+        # line end comments has been printed after last meaningful statement
         return
 
     if ctx.opts.yang_remove_unused_imports and stmt.keyword == 'import':
@@ -243,7 +243,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
     fd.write(eol)
 
     next_stmt = link_list.get(stmt, None)
-    emit_line_end_comments_after(stmt, next_stmt, link_list, fd, False)
+    emit_line_end_comments(stmt, next_stmt, link_list, fd, False)
     fd.write('\n')
 
     if len(stmt.substmts) > 0:
@@ -278,7 +278,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
         last_substmt = link_list['last']
         if last_substmt in link_list:
             last_substmt = link_list[last_substmt]
-        emit_line_end_comments_after(stmt, last_substmt, link_list, fd, True)
+        emit_line_end_comments(stmt, last_substmt, link_list, fd, True)
         fd.write('\n')
 
     if (not islast and
@@ -287,16 +287,22 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
          stmt.keyword in _keyword_with_trailing_blank_line)):
         fd.write('\n')
 
-def emit_line_end_comments_after(stmt, last_substmt, link_list, fd, need_same_level):
-    while last_substmt is not None:
+def emit_line_end_comments(stmt, next_stmt, link_list, fd, same_level):
+    """
+    emit line end comment stmts, there are some cases:
+    1. after "{"
+    2. after "}"
+    3. multi line end comments should be printed in oneline
+    """
+    while next_stmt is not None:
         is_sub_level = False
-        if not need_same_level:
-            is_sub_level = last_substmt.parent == stmt
-        if (is_line_end_comment(last_substmt) and
-                (last_substmt.parent == stmt.parent or (not need_same_level and is_sub_level))):
-            fd.write(' ' + last_substmt.arg)
-            if last_substmt in link_list:
-                last_substmt = link_list[last_substmt]
+        if not same_level:
+            is_sub_level = next_stmt.stmt_parent == stmt
+        if (is_line_end_comment(next_stmt) and
+                (next_stmt.stmt_parent == stmt.stmt_parent or (not same_level and is_sub_level))):
+            fd.write(' ' + next_stmt.arg)
+            if next_stmt in link_list:
+                next_stmt = link_list[next_stmt]
             else:
                 return
         else:

--- a/test/test_issues/test_i760/Makefile
+++ b/test/test_issues/test_i760/Makefile
@@ -1,0 +1,4 @@
+test: test1
+
+test1:
+	pyang mod1.yang -f yang 2>&1 | diff mod1.expect -

--- a/test/test_issues/test_i760/mod1.expect
+++ b/test/test_issues/test_i760/mod1.expect
@@ -1,0 +1,13 @@
+module mod1 {
+  namespace "urn:a";
+  prefix a;
+
+  container x;
+
+  augment "/x" {
+    container dm {
+      presence "x";
+    } // dm
+  } // augment
+
+}

--- a/test/test_issues/test_i760/mod1.yang
+++ b/test/test_issues/test_i760/mod1.yang
@@ -1,0 +1,12 @@
+module mod1 {
+  namespace "urn:a";
+  prefix a;
+
+  container x;
+
+  augment "/x" {
+    container dm {
+      presence "x";
+    }// dm
+  } // augment
+}


### PR DESCRIPTION
Currently the "parent" property in Statement class is not purely used for statement tree.
But this property is used for line end comment printing. So we need one "stmt_parent" property more. This property will not be modified since Statement init.

This will fix #760 issue.

@mbj4668 Please review this.