### PR TITLE
test_bad: skip access.yang if running as root

### DIFF
--- a/test/test_bad/Makefile
+++ b/test/test_bad/Makefile
@@ -7,13 +7,17 @@ MODULES = $(wildcard *.yang)
 
 test: subdirs
 	@chmod -r access.yang
-	for m in $(MODULES); do						\
-		echo "trying $$m..." | tr -d '\012';			\
-		$(PYANG) $$m 2> $$m.out;				\
-		diff expect/$$m.out $$m.out > $$m.diff || 		\
-			{ cat $$m.diff; exit 1; };			\
-		rm -f $$m.diff;						\
-		echo " ok";						\
+	for m in $(MODULES); do							\
+		if [ "$$m" = "access.yang" ] && [ "$$(id -u)" = "0" ]; then	\
+			echo "Running as root - skipping access.yang";		\
+			continue;						\
+		fi;								\
+		echo "trying $$m..." | tr -d '\012';				\
+		$(PYANG) $$m 2> $$m.out;					\
+		diff expect/$$m.out $$m.out > $$m.diff || 			\
+			{ cat $$m.diff; exit 1; };				\
+		rm -f $$m.diff;							\
+		echo " ok";							\
 	done
 	chmod +r access.yang
 


### PR DESCRIPTION
If the tests are being run as the root user then the access.yang test
will fail, since it can always be read by the root user, even if the
read permission has been removed.