### PR TITLE
Fixes #775 - correct multi-line argument wrapping when generating YANG

### DIFF
--- a/pyang/translators/yang.py
+++ b/pyang/translators/yang.py
@@ -216,7 +216,7 @@ def emit_stmt(ctx, stmt, fd, level, prev_kwd, prev_kwd_class, islast,
         elif '\n' in stmt.arg:
             # the arg string contains newlines; print it as double quoted
             arg_on_new_line = emit_arg(keywordstr, stmt, fd, indent, indentstep,
-                                       max_line_len, line_len)
+                                       max_line_len, line_len - 1 - len(eol))
         elif stmt.keyword in _keyword_with_path_arg:
             # special code for path argument; pretty-prints a long path with
             # line breaks
@@ -457,7 +457,7 @@ def emit_arg(keywordstr, stmt, fd, indent, indentstep, max_line_len, line_len):
             need_nl = True
         else:
             for line in lines:
-                if need_new_line(max_line_len, line_len + 1, line):
+                if need_new_line(max_line_len, line_len, line):
                     need_nl = True
                     break
         if need_nl:

--- a/test/test_yang/Makefile
+++ b/test/test_yang/Makefile
@@ -1,4 +1,4 @@
-PYANG := $(PYANG) -Wnone
+PYANG := $(or $(PYANG), pyang) -Wnone
 
 MODULES ?= $(wildcard *.yang)
 

--- a/test/test_yang/expect/presence_bug_i775--yang-line-length_65.yang
+++ b/test/test_yang/expect/presence_bug_i775--yang-line-length_65.yang
@@ -1,0 +1,20 @@
+module presence_bug_i775 {
+  namespace "urn:presence-bug";
+  prefix presence-bug;
+
+  container root {
+    container aardvark {
+      description
+        "The length of the next line is 66.";
+      presence
+        "Presence of an aardvark strongly suggests that the
+         'a' key is working correctly.";
+    }
+    container bison {
+      description
+        "The length of the next line is 66.";
+      presence
+        "Presence of a bison suggests that we should run.";
+    }
+  }
+}

--- a/test/test_yang/expect/presence_bug_i775--yang-line-length_66.yang
+++ b/test/test_yang/expect/presence_bug_i775--yang-line-length_66.yang
@@ -1,0 +1,18 @@
+module presence_bug_i775 {
+  namespace "urn:presence-bug";
+  prefix presence-bug;
+
+  container root {
+    container aardvark {
+      description
+        "The length of the next line is 66.";
+      presence "Presence of an aardvark strongly suggests that the
+                'a' key is working correctly.";
+    }
+    container bison {
+      description
+        "The length of the next line is 66.";
+      presence "Presence of a bison suggests that we should run.";
+    }
+  }
+}

--- a/test/test_yang/expect/presence_bug_i775.yang
+++ b/test/test_yang/expect/presence_bug_i775.yang
@@ -1,0 +1,18 @@
+module presence_bug_i775 {
+  namespace "urn:presence-bug";
+  prefix presence-bug;
+
+  container root {
+    container aardvark {
+      description
+        "The length of the next line is 66.";
+      presence "Presence of an aardvark strongly suggests that the
+                'a' key is working correctly.";
+    }
+    container bison {
+      description
+        "The length of the next line is 66.";
+      presence "Presence of a bison suggests that we should run.";
+    }
+  }
+}

--- a/test/test_yang/presence_bug_i775--yang-line-length_65.yang
+++ b/test/test_yang/presence_bug_i775--yang-line-length_65.yang
@@ -1,0 +1,1 @@
+presence_bug_i775.yang

--- a/test/test_yang/presence_bug_i775--yang-line-length_66.yang
+++ b/test/test_yang/presence_bug_i775--yang-line-length_66.yang
@@ -1,0 +1,1 @@
+presence_bug_i775.yang

--- a/test/test_yang/presence_bug_i775.yang
+++ b/test/test_yang/presence_bug_i775.yang
@@ -1,0 +1,15 @@
+module presence_bug_i775 {
+  namespace "urn:presence-bug";
+  prefix presence-bug;
+  container root {
+    container aardvark {
+      description "The length of the next line is 66.";
+      presence "Presence of an aardvark strongly suggests that the
+                'a' key is working correctly.";
+    }
+    container bison {
+      description "The length of the next line is 66.";
+      presence "Presence of a bison suggests that we should run.";
+    }
+  }
+}


### PR DESCRIPTION
I added some comments to the commit. In summary, I think there were two problems:

- `line_len` was already incremented on the assumption that the argument is a single line (so it added 1 for the closing quote and 1 or 2 for `;` or ` {`)
- `need_new_line()` was called with `line_len + 1` that I think should be `line_len`

The first problem accounted for an error of `2` and the second for an error of `1`, giving the observed error of `3`.