### PR TITLE
Disable writing of Yacc parse tables to files

### DIFF
--- a/pyang/xpath_parser.py
+++ b/pyang/xpath_parser.py
@@ -354,4 +354,4 @@ precedence = (
 
 tokens = xpath_lexer.token_defs()
 lexer = xpath_lexer.XPathLexer()
-parser = yacc.yacc(tabmodule="xpath_parsetab", debug=False)
+parser = yacc.yacc(tabmodule="xpath_parsetab", debug=False, write_tables=False)


### PR DESCRIPTION
When multiple Pyang instances are run in parallel, one instance may overwrite the parse table files at the same time they are read by another instance. Consequently, the second instance crashes when failing to interpret truncated Python code. By disabling writing tables to files, this race is avoided.