### PR TITLE
do not mark modules are being removed

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -732,7 +732,7 @@ class SidFile:
             status = ""
             if item['status'] == 'n' and not self.sid_file_created:
                 status = " (New)"
-            if item['status'] == 'd':
+            if item['status'] == 'd' and item['namespace'] != 'module':
                 status = " (Remove)"
                 definition_removed = True
 


### PR DESCRIPTION
When formatting the sid output we were seeing:

    WARNING, obsolete definitions should be defined as 'deprecated' or 'obsolete'.

because of some post-processing, it wasn't obvious at first that this was because the "module" statements were all being marked as removed.  It is not clear to me why this is.  I've tried removing the SID allocation for the modules, but that didn't help.

This match restricts the setting to not apply to modules. That's probably the wrong thing to do.
Test examples can be provided, but they are complex to do.