### PR TITLE
Fixes #802 - init i_is_primary_module attribute

### DIFF
--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -3132,11 +3132,14 @@ class ModSubmodStatement(Statement):
 
     def __init__(self, top, parent, pos, keyword, arg=None):
         Statement.__init__(self, top, parent, pos, keyword, arg)
-        self.i_is_primary_module = False
-        self.i_is_validated = False
+        self._init_i_attrs()
 
     def internal_reset(self):
         Statement.internal_reset(self)
+        self._init_i_attrs()
+
+    def _init_i_attrs(self):
+        self.i_is_primary_module = False
         self.i_is_validated = False
 
     def prune(self):


### PR DESCRIPTION
Thanks to @jboyd77 for pointing out this problem, and for the fix.

See issue #802 for context. The proposed fix adds an `_init_i_attrs()` method (called from `ModSubmodStatement.__init__()` and `ModSubmodStatement.internal_reset()`) in order to prevent this from happening again the next time such an internal attribute (i.e., one that requires initialization) is added. It already happened in PR #580!

I didn't add a test case (the change seems rather obviously to fix the problem) but could do so if requested.