### PR TITLE
Fix issue #809: revision-date parsed wrong if >1 @ in path

### DIFF
--- a/pyang/syntax.py
+++ b/pyang/syntax.py
@@ -1,5 +1,6 @@
 """Description of YANG & YIN syntax."""
 
+import os
 import re
 import shlex
 import sys
@@ -129,10 +130,12 @@ re_descendant_schema_nodeid = re.compile("^" + descendant_schema_nodeid + "$")
 re_deviate = re.compile(r"^(add|delete|replace|not-supported)$")
 
 # Not part of YANG syntax per se but useful for pyang in several places
-re_filename = re.compile(r"^([^@]*?)" +          # putative module name
-                         r"(?:@([^.]*?))?" +     # putative revision
-                         r"(?:\.yang|\.yin)*" +  # foo@bar.yang.yin.yang.yin ?
-                         r"\.(yang|yin)$")       # actual final extension
+re_filename = re.compile(
+    r"^(?:.*" + os.sep + r")?" +    # ignore all before os.sep
+    r"([^@]*?)" +                   # putative module name
+    r"(?:@([^.]*?))?" +             # putative revision
+    r"(?:\.yang|\.yin)*" +          # foo@bar.yang.yin.yang.yin ?
+    r"\.(yang|yin)$")               # actual final extension
 
 arg_type_map = {
     "identifier": lambda s: re_identifier.search(s) is not None,

--- a/test/test_issues/test_i809/Makefile
+++ b/test/test_issues/test_i809/Makefile
@@ -1,0 +1,2 @@
+test:
+	pyang -Werror project@2022-04-07/project@2022-04-07.yang

--- a/test/test_issues/test_i809/project@2022-04-07/project@2022-04-07.yang
+++ b/test/test_issues/test_i809/project@2022-04-07/project@2022-04-07.yang
@@ -1,0 +1,13 @@
+module project {
+  yang-version 1;
+  namespace "urn:at-char-in-path:project:1";
+  prefix p;
+
+  description "'@' char in parent dir of file confuses the revision date parsing";
+
+  revision 2022-04-07;
+
+  leaf foo {
+    type string;
+  }
+}


### PR DESCRIPTION
If `bin/pyang` is given a path to a YANG file which contains more than
one '@' character (e.g. if there's an '@' in a parent directory), the
`re_filename` regexp will detect the revision-date as being everything
from the first instances of the '@' char in the path, to the yang/tin
suffix(es).

This fails to match the expected 'YYYY-MM-DD' date format that the
revision-date in the filename should take and `pyang` fails.

This commit fixes `re_filename` regexp so that it disregards all
characters in the filepath before the last directory separator (based
on the value of `os.sep`) in the string.