### PR TITLE
bugfix: test_feature make test failed and remove make clean

### DIFF
--- a/test/test_feature/Makefile
+++ b/test/test_feature/Makefile
@@ -35,6 +35,3 @@ exclude-foo:
 
 exclude-both:
 	$(PYANG) --exclude-features feature:has-leaf-foo,has-leaf-goo $(POST)
-
-clean:
-	$(RM) -f $(wildcard *.expect)

--- a/test/test_feature/include-exclude-different.expect
+++ b/test/test_feature/include-exclude-different.expect
@@ -1,4 +1,4 @@
-# module feature: features ['has-leaf-foo', 'has-leaf-goo'] exclude_features []
+# module feature: features has-leaf-foo,has-leaf-goo exclude_features []
 module: feature
   +--rw root
      +--rw foo?   string {has-leaf-foo}?


### PR DESCRIPTION
1. 
In `test/test_feature` directory,  the *.expect files are needed for diff, but `make clean` will delete them. So I remove the `make clean` in `Makefile`

2. Output are not symmetrical, I adjust a bit in `feature.py` and the expect files.
3. `include-exclude-different` failed, I modify the expect file.

Please have a look at this. Thanks @wlupton 