### PR TITLE
do not remove sid file before writing it

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -761,10 +761,8 @@ class SidFile:
         for item in self.content['items']:
             del item['status']
 
-        if os.path.exists(self.output_file_name):
-            os.remove(self.output_file_name)
-
         with open(self.output_file_name, 'w') as outfile:
+            outfile.truncate(0)
             json.dump(self.content, outfile, indent=2)
 
     ########################################################


### PR DESCRIPTION
rather than removing a file (and possibly the carefully crafted symlink), just truncate the file after opening.
This allows for creative symlinks to deal with #841 writing the file in the wrong place.
