### PR TITLE
Add latest revision date to output of depend.

### DIFF
--- a/pyang/plugins/depend.py
+++ b/pyang/plugins/depend.py
@@ -46,6 +46,10 @@ class DependPlugin(plugin.PyangPlugin):
                                  help="(sub)module to ignore in the" \
                                      " prerequisites.  This option can be" \
                                      " given multiple times."),
+            optparse.make_option("--depend-include-revision",
+                                 dest="depend_include_revision",
+                                 action="store_true",
+                                 help="Include latest revision in output"),
             ]
         g = optparser.add_option_group("Depend output specific options")
         g.add_options(optlist)
@@ -65,6 +69,8 @@ def emit_depend(ctx, modules, fd):
     for module in modules:
         if ctx.opts.depend_target is None:
             fd.write('%s :' % module.pos.ref)
+            if ctx.opts.depend_include_revision:
+                fd.write(', %s\n' % module.i_latest_revision)
         else:
             fd.write('%s :' % ctx.opts.depend_target)
         prereqs = []
@@ -80,6 +86,9 @@ def emit_depend(ctx, modules, fd):
                     basename = os.path.splitext(m.pos.ref)[0]
                     filename = '%s%s' % (basename, ctx.opts.depend_extension)
                 fd.write(' %s' % filename)
+            elif ctx.opts.depend_include_revision:
+                m = ctx.get_module(i)
+                fd.write('%s, %s\n' % (i, m.i_latest_revision))
             else:
                 if ctx.opts.depend_extension is None:
                     ext = ""


### PR DESCRIPTION
Output is comma delimited with newlines which is CSV friendly. Example output file:
```
(pyats) /Users/miott/pyang/plugin # cat ocinst-depend.csv 
/Users/miott/ysuite/install/data/users/yangsuite-developer/repositories/ddmi-9500-2-default-repo/openconfig-network-instance@2021-01-25.yang :,2021-01-25
ietf-yang-types,2013-07-15
ietf-inet-types,2013-07-15
openconfig-network-instance-types,2021-05-21
openconfig-policy-types,2016-05-12
openconfig-routing-policy,2016-05-12
openconfig-local-routing,2016-05-11
openconfig-interfaces,2018-01-05
openconfig-extensions,2020-06-16
openconfig-network-instance-l3,2018-11-21
openconfig-types,2019-04-16
openconfig-bgp,2016-06-21
openconfig-mpls,2016-12-15
openconfig-vlan,2016-05-26
openconfig-ospfv2,2021-03-17
openconfig-policy-forwarding,2021-05-19
openconfig-segment-routing,2017-01-12
openconfig-isis,2017-01-13
openconfig-aft,2017-01-13
openconfig-pim,2021-04-21
openconfig-igmp,2019-07-09
openconfig-evpn,2020-11-24
openconfig-network-instance-l2,2021-01-25
ietf-interfaces,2018-02-20
openconfig-yang-types,2018-11-21
openconfig-bgp-common,2016-06-21
openconfig-bgp-common-multiprotocol,2016-06-21
openconfig-bgp-common-structure,2016-06-21
openconfig-bgp-peer-group,2016-06-21
openconfig-bgp-neighbor,2016-06-21
openconfig-bgp-global,2016-06-21
openconfig-bgp-types,2016-06-21
openconfig-mpls-types,2016-12-15
openconfig-mpls-rsvp,2016-12-15
openconfig-mpls-ldp,2016-12-15
openconfig-mpls-te,2016-12-15
openconfig-mpls-igp,2016-12-15
openconfig-mpls-static,2016-12-15
openconfig-mpls-sr,2016-12-15
openconfig-vlan-types,2016-05-26
openconfig-if-ethernet,2020-05-06
openconfig-if-aggregate,2018-01-05
iana-if-type,2019-02-08
openconfig-ospfv2-global,2019-11-28
openconfig-ospfv2-area,2019-11-28
openconfig-ospfv2-area-interface,2021-03-17
openconfig-ospfv2-lsdb,2019-11-28
openconfig-ospfv2-common,2019-11-28
openconfig-ospf-types,2018-11-21
openconfig-bfd,2021-03-17
openconfig-if-types,2018-11-21
openconfig-inet-types,2017-08-24
openconfig-pf-forwarding-policies,2021-05-19
openconfig-pf-path-groups,2021-05-19
openconfig-pf-interfaces,2021-05-19
openconfig-packet-match,2017-05-26
openconfig-packet-match-types,2017-05-26
openconfig-isis-types,2017-01-13
openconfig-isis-lsp,2017-01-13
openconfig-isis-routing,2017-01-13
openconfig-isis-lsdb-types,2017-01-13
openconfig-aft-types,2017-01-13
openconfig-pim-types,2018-11-21
openconfig-acl,2017-05-26
openconfig-igmp-types,2018-11-21
openconfig-evpn-types,2020-10-08
(pyats) /Users/miott/pyang/plugin #
```