### PR TITLE
Sid item status

### DIFF
--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -761,10 +761,8 @@ class SidFile:
         for item in self.content['items']:
             del item['status']
 
-        if os.path.exists(self.output_file_name):
-            os.remove(self.output_file_name)
-
         with open(self.output_file_name, 'w') as outfile:
+            outfile.truncate(0)
             json.dump(self.content, outfile, indent=2)
 
     ########################################################

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -511,7 +511,8 @@ class SidFile:
     ########################################################
     # Verify if each SID listed in items is in range and is not duplicate.
     def validate_sid(self):
-        self.content['items'].sort(key=lambda item: item['sid'])
+        if self.content['items'] is not None:
+            self.content['items'].sort(key=lambda item: item['sid'])
         last_sid = -1
         for item in self.content['items']:
             sid = item['sid']
@@ -728,7 +729,10 @@ class SidFile:
 
         print("\nSID        Assigned to")
         print("---------  --------------------------------------------------")
-        for item in self.content['items']:
+        items = self.content['items']
+        if items is not None:
+            items.sort(key=lambda item: item['sid'])
+        for item in items:
             status = ""
             if item['status'] == 'n' and not self.sid_file_created:
                 status = " (New)"
@@ -761,11 +765,8 @@ class SidFile:
         for item in self.content['items']:
             del item['status']
 
-        def sidkey(assignment):
-            return assignment['sid']
-
         myorderedstuff = self.content.copy()
-        myorderedstuff['items'].sort(key=sidkey)
+        myorderedstuff['items'].sort(key=lambda item: item['sid'])
 
         with open(self.output_file_name, 'w') as outfile:
             outfile.truncate(0)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -55,6 +55,10 @@ class SidPlugin(plugin.PyangPlugin):
                                  action="store_true",
                                  dest="list_sid",
                                  help="Print the list of SID."),
+            optparse.make_option("--sid-finalize",
+                                 action="store_true",
+                                 dest="finalize_sid",
+                                 help="Mark current allocations as non-provisional."),
             optparse.make_option("--sid-registration-info",
                                  action="store_true",
                                  dest="sid_registration_info",
@@ -221,6 +225,19 @@ OPTIONS
   obtains the list of SIDs assigned or validated. For example:
 
   $ pyang --sid-list --sid-generate-file 20000:100 toaster@2009-11-20.yang
+
+--sid-finalize
+
+  New allocations when during development of a protocol are marked as
+  "provisional", unless --sid-finalize is specified, then they are marked with
+  a status given by the module-revision of the YANG module.
+
+  When --sid-finalize is specified, any items marked provisional are also
+  marked with the module-revision.
+
+  Otherwise, any new allocations are marked "unstable"
+
+  $ pyang --sid-list --sid-generate-file 20000:100 --sid-finalize toaster@2009-11-20.yang
 
 --sid-extra-range
 

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -134,6 +134,12 @@ class SidPlugin(plugin.PyangPlugin):
         if ctx.opts.list_sid:
             sid_file.list_content = True
 
+        if ctx.opts.finalize_sid:
+            print("Will mark unstable allocations finalized")
+            sid_file.check_consistency = False
+            sid_file.is_consistent = False
+            sid_file.finalize_sid  = True
+
         try:
             sid_file.process_sid_file(modules[0])
 
@@ -278,6 +284,7 @@ class SidFile:
         self.is_consistent = True
         self.check_consistency = False
         self.list_content = False
+        self.finalize_sid = False
         self.sid_registration_info = False
         self.input_file_name = None
         self.range = None
@@ -793,6 +800,13 @@ class SidFile:
 
         myorderedstuff = self.content.copy()
         myorderedstuff['items'].sort(key=lambda item: item['sid'])
+
+        if self.finalize_sid:
+            print("Finalizing unstable allocations to %s" % (self.module_revision))
+            for item in myorderedstuff['items']:
+                if item['status'] == 'unstable':
+                    print("  finalized %s" % (item['identifier']))
+                    item['status'] = self.module_revision
 
         with open(self.output_file_name, 'w') as outfile:
             outfile.truncate(0)

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -461,6 +461,7 @@ class SidFile:
         namespace_absent = True
         identifier_absent = True
         sid_absent = True
+        status_absent = True
         for item in items:
             for key in item:
                 if key == 'namespace':
@@ -477,6 +478,11 @@ class SidFile:
                 elif key == 'sid':
                     sid_absent = False
                     if not isinstance(item[key], util.int_types):
+                        raise SidFileError("invalid 'sid' value '%s'." % item[key])
+
+                elif key == 'status':
+                    status_absent = False
+                    if not isinstance(item[key], util.str_types):
                         raise SidFileError("invalid 'sid' value '%s'." % item[key])
 
                 else:

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -761,9 +761,15 @@ class SidFile:
         for item in self.content['items']:
             del item['status']
 
+        def sidkey(assignment):
+            return assignment['sid']
+
+        myorderedstuff = self.content.copy()
+        myorderedstuff['items'].sort(key=sidkey)
+
         with open(self.output_file_name, 'w') as outfile:
             outfile.truncate(0)
-            json.dump(self.content, outfile, indent=2)
+            json.dump(myorderedstuff, outfile, indent=2)
 
     ########################################################
     def number_of_sids_allocated(self):

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -689,6 +689,7 @@ class SidFile:
         for item in unassigned:
             try:
                 item['sid'] = next(source)
+                item['status'] = 'unstable'
             except StopIteration:
                 raise SidParsingError(
                     "The current SID range(s) are exhausted, %d extra SID(s) "

--- a/pyang/plugins/sid.py
+++ b/pyang/plugins/sid.py
@@ -556,7 +556,7 @@ class SidFile:
             self.content['items'] = []
 
         for item in self.content['items']:
-            item['status'] = 'd' # Set to 'd' deleted, updated to 'o' if present in .yang file
+            item['lifecycle'] = 'd' # Set to 'd' deleted, updated to 'o' if present in .yang file
 
         self.merge_item('module', self.module_name)
 
@@ -661,10 +661,12 @@ class SidFile:
     def merge_item(self, namespace, identifier):
         for item in self.content['items']:
             if (namespace == item['namespace'] and identifier == item['identifier']):
-                item['status'] = 'o' # Item already assigned
+                item['lifecycle'] = 'o' # Item already assigned
                 return
         self.content['items'].append(collections.OrderedDict(
-            [('namespace', namespace), ('identifier', identifier), ('sid', -1), ('status', 'n')]))
+            [('namespace', namespace), ('identifier', identifier),
+             ('status', 'unstable'),
+             ('sid', -1), ('lifecycle', 'n')]))
         self.is_consistent = False
 
     ########################################################
@@ -740,9 +742,9 @@ class SidFile:
             items.sort(key=lambda item: item['sid'])
         for item in items:
             status = ""
-            if item['status'] == 'n' and not self.sid_file_created:
+            if item['lifecycle'] == 'n' and not self.sid_file_created:
                 status = " (New)"
-            if item['status'] == 'd' and item['namespace'] != 'module':
+            if item['lifecycle'] == 'd' and item['namespace'] != 'module':
                 status = " (Remove)"
                 definition_removed = True
 
@@ -756,7 +758,7 @@ class SidFile:
     def list_deleted_items(self):
         definition_removed = False
         for item in self.content['items']:
-            if item['status'] == 'd':
+            if item['lifecycle'] == 'd':
                 print("WARNING, item '%s' was deleted form the .yang files." % item['identifier'])
                 definition_removed = True
 
@@ -769,7 +771,7 @@ class SidFile:
     ########################################################
     def generate_file(self):
         for item in self.content['items']:
-            del item['status']
+            del item['lifecycle']
 
         myorderedstuff = self.content.copy()
         myorderedstuff['items'].sort(key=lambda item: item['sid'])

--- a/test/test_sid/.gitignore
+++ b/test/test_sid/.gitignore
@@ -1,0 +1,2 @@
+OUTPUT
+toaster@2009-12-28.sid

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -12,9 +12,9 @@ test2:
 	rm toaster@2009-11-20.sid
 
 test3:
-	# Test update sid file
+	# Test update sid file (test3)
 	cp test-2-expected-toaster@2009-11-20.sid toaster@2009-11-20.sid
-	$(PYANG) --sid-list --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | diff -b test-3-expected-output.txt -
+	$(PYANG) --sid-list --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang 2>&1 | tee OUTPUT/test-3-expected-output.txt | diff -b test-3-expected-output.txt -
 	diff -b test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
 	rm toaster@2009-11-20.sid toaster@2009-12-28.sid
 

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -3,7 +3,7 @@ PYANG?= pyang
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test14 test15 test16 test17 test18 test19 test20
 test1:
 	# Test help
-	$(PYANG) --sid-help 2>&1 | diff -b test-1-expected-output.txt -
+	$(PYANG) --sid-help 2>&1 | diff -w test-1-expected-output.txt -
 
 test2:
 	# Test generate sid file

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -1,6 +1,7 @@
 PYANG?= pyang
 
-test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test14 test15 test16 test17 test18 test19 test20
+test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test14 test15 test16 test17 test18 test19 test20 test21
+
 test1:
 	# Test help
 	$(PYANG) --sid-help 2>&1 | diff -w test-1-expected-output.txt -
@@ -101,7 +102,7 @@ test21:
 	# Test finalize of sid file
 	cp test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
 	mkdir -p OUTPUT
-	$(PYANG) --sid-update-file toaster@2009-12-28.sid --sid-finalize toaster@2019-01-01.yang 2>&1 | tee OUTPUT/test-21-expected-output.txt | diff -b test-21-expected-output.txt -
+	$(PYANG) --sid-update-file toaster@2009-12-28.sid --sid-finalize toaster@2009-12-28.yang 2>&1 | tee OUTPUT/test-21-expected-output.txt | diff -b test-21-expected-output.txt -
 	diff -b toaster@2009-12-28.sid test-21-expected-toaster@2009-12-28.sid
 	rm toaster@2009-12-28.sid
 

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -96,3 +96,12 @@ test20:
 	$(PYANG) --sid-generate-file 60000:100 ieee802-dot1q-psfp@2020-07-07.yang 2>&1 | diff -b test-20-expected-output.txt -
 	diff -b test-20-expected-ieee802-dot1q-psfp@2020-07-07.sid ieee802-dot1q-psfp@2020-07-07.sid
 	rm ieee802-dot1q-psfp@2020-07-07.sid
+
+test21:
+	# Test finalize of sid file
+	cp test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
+	mkdir -p OUTPUT
+	$(PYANG) --sid-update-file toaster@2009-12-28.sid --sid-finalize toaster@2019-01-01.yang 2>&1 | tee OUTPUT/test-21-expected-output.txt | diff -b test-21-expected-output.txt -
+	diff -b toaster@2009-12-28.sid test-21-expected-toaster@2009-12-28.sid
+	rm toaster@2009-12-28.sid
+

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -1,3 +1,5 @@
+PYANG?= pyang
+
 test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test14 test15 test16 test17 test18 test19 test20
 test1:
 	# Test help

--- a/test/test_sid/Makefile
+++ b/test/test_sid/Makefile
@@ -29,11 +29,11 @@ test5:
 	$(PYANG) --sid-generate-file 2500:50 ietf-constrained-voucher@2019-08-01.yang 2>&1 | diff -b test-5-expected-output.txt -
 	diff -b test-5-expected-ietf-constrained-voucher@2019-08-01.sid ietf-constrained-voucher@2019-08-01.sid
 	rm ietf-constrained-voucher@2019-08-01.sid
-  
+
 test6:
 	# Test SID range exhausted
 	cp test-3-expected-toaster@2009-12-28.sid toaster@2009-12-28.sid
-	$(PYANG) --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang 2>&1 | diff -b test-6-expected-output.txt - 
+	$(PYANG) --sid-update-file toaster@2009-12-28.sid toaster@2019-01-01.yang 2>&1 | diff -b test-6-expected-output.txt -
 	rm toaster@2009-12-28.sid
 
 test7:
@@ -46,7 +46,7 @@ test7:
 	rm -f toaster@2009-11-20.sid toaster@2009-12-28.sid toaster@2019-01-01.sid
 
 test8:
-	# In generate sid file, test count 
+	# In generate sid file, test count
 	$(PYANG) --sid-generate-file count toaster@2009-11-20.yang 2>&1 | diff -b test-8-expected-output.txt -
 
 test9:

--- a/test/test_sid/test-1-expected-output.txt
+++ b/test/test_sid/test-1-expected-output.txt
@@ -18,7 +18,7 @@ OPTIONS
 --sid-generate-file
 
   This option is used to generate a new .sid file from a YANG module.
-  
+
   Two arguments are required to generate a .sid file; the SID range assigned to
   the YANG module and its definition file. The SID range specified is a
   sub-range within a range obtained from a registrar or a sub-range within the
@@ -27,11 +27,11 @@ OPTIONS
   allocated to the YANG module. The filename consists of the module name,
   followed by an @ symbol, followed by the module revision, followed by the
   ".yang" extension.
-           
+
   This example shows how to generate the file toaster@2009-11-20.sid.
 
   $ pyang --sid-generate-file 20000:100 toaster@2009-11-20.yang
-  
+
 --sid-update-file
 
   Each time new items are added to a YANG module by the introduction of a new
@@ -49,7 +49,7 @@ OPTIONS
   on the SIDs already present in toaster@2009-11-20.sid.
 
   $ pyang --sid-update-file toaster@2009-11-20.sid toaster@2009-12-28.yang
-  
+
 -- sid-check-file
 
   The --sid-check-file option can be used at any time to verify if a .sid file
@@ -61,14 +61,27 @@ OPTIONS
   For example:
 
   $ pyang --sid-check-file toaster@2009-12-28.sid toaster@2009-12-28.yang
-  
+
 --sid-list
 
   The --sid-list option can be used before any of the previous options to
   obtains the list of SIDs assigned or validated. For example:
 
   $ pyang --sid-list --sid-generate-file 20000:100 toaster@2009-11-20.yang
-  
+
+--sid-finalize
+
+  New allocations when during development of a protocol are marked as
+  "provisional", unless --sid-finalize is specified, then they are marked with
+  a status given by the module-revision of the YANG module.
+
+  When --sid-finalize is specified, any items marked provisional are also
+  marked with the module-revision.
+
+  Otherwise, any new allocations are marked "unstable"
+
+  $ pyang --sid-list --sid-generate-file 20000:100 --sid-finalize toaster@2009-11-20.yang
+
 --sid-extra-range
 
   If needed, an extra SID range can be assigned to an existing YANG module
@@ -80,7 +93,7 @@ OPTIONS
 
   $ pyang --sid-update-file toaster@2009-11-20.sid
           toaster@2009-12-28.yang --sid-extra-range 20100:100
-  
+
 --sid-extra-range-count
   The number of SID required when generating or updating a .sid file can be
   computed by specifying "count" as SID range.

--- a/test/test_sid/test-2-expected-toaster@2009-11-20.sid
+++ b/test/test_sid/test-2-expected-toaster@2009-11-20.sid
@@ -1,101 +1,101 @@
 {
   "assignment-ranges": [
     {
-      "entry-point": 20000, 
+      "entry-point": 20000,
       "size": 25
     }
-  ], 
-  "module-name": "toaster", 
-  "module-revision": "2009-11-20", 
+  ],
+  "module-name": "toaster",
+  "module-revision": "2009-11-20",
   "items": [
     {
-      "namespace": "module", 
-      "identifier": "toaster", 
+      "namespace": "module",
+      "identifier": "toaster",
       "sid": 20000
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "frozen-bagel", 
+      "namespace": "identity",
+      "identifier": "frozen-bagel",
       "sid": 20001
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "frozen-waffle", 
+      "namespace": "identity",
+      "identifier": "frozen-waffle",
       "sid": 20002
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "hash-brown", 
+      "namespace": "identity",
+      "identifier": "hash-brown",
       "sid": 20003
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "toast-type", 
+      "namespace": "identity",
+      "identifier": "toast-type",
       "sid": 20004
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "wheat-bread", 
+      "namespace": "identity",
+      "identifier": "wheat-bread",
       "sid": 20005
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "white-bread", 
+      "namespace": "identity",
+      "identifier": "white-bread",
       "sid": 20006
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "wonder-bread", 
+      "namespace": "identity",
+      "identifier": "wonder-bread",
       "sid": 20007
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:cancel-toast", 
+      "namespace": "data",
+      "identifier": "/toaster:cancel-toast",
       "sid": 20008
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:make-toast", 
+      "namespace": "data",
+      "identifier": "/toaster:make-toast",
       "sid": 20009
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:make-toast/input/toasterDoneness", 
+      "namespace": "data",
+      "identifier": "/toaster:make-toast/input/toasterDoneness",
       "sid": 20010
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:make-toast/input/toasterToastType", 
+      "namespace": "data",
+      "identifier": "/toaster:make-toast/input/toasterToastType",
       "sid": 20011
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toastDone", 
+      "namespace": "data",
+      "identifier": "/toaster:toastDone",
       "sid": 20012
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toastDone/toastStatus", 
+      "namespace": "data",
+      "identifier": "/toaster:toastDone/toastStatus",
       "sid": 20013
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster",
       "sid": 20014
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/toasterManufacturer", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterManufacturer",
       "sid": 20015
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/toasterModelNumber", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterModelNumber",
       "sid": 20016
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/toasterStatus", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterStatus",
       "sid": 20017
     }
   ]

--- a/test/test_sid/test-2-expected-toaster@2009-11-20.sid
+++ b/test/test_sid/test-2-expected-toaster@2009-11-20.sid
@@ -11,91 +11,109 @@
     {
       "namespace": "module",
       "identifier": "toaster",
+      "status": "unstable",
       "sid": 20000
     },
     {
       "namespace": "identity",
       "identifier": "frozen-bagel",
+      "status": "unstable",
       "sid": 20001
     },
     {
       "namespace": "identity",
       "identifier": "frozen-waffle",
+      "status": "unstable",
       "sid": 20002
     },
     {
       "namespace": "identity",
       "identifier": "hash-brown",
+      "status": "unstable",
       "sid": 20003
     },
     {
       "namespace": "identity",
       "identifier": "toast-type",
+      "status": "unstable",
       "sid": 20004
     },
     {
       "namespace": "identity",
       "identifier": "wheat-bread",
+      "status": "unstable",
       "sid": 20005
     },
     {
       "namespace": "identity",
       "identifier": "white-bread",
+      "status": "unstable",
       "sid": 20006
     },
     {
       "namespace": "identity",
       "identifier": "wonder-bread",
+      "status": "unstable",
       "sid": 20007
     },
     {
       "namespace": "data",
       "identifier": "/toaster:cancel-toast",
+      "status": "unstable",
       "sid": 20008
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast",
+      "status": "unstable",
       "sid": 20009
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast/input/toasterDoneness",
+      "status": "unstable",
       "sid": 20010
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast/input/toasterToastType",
+      "status": "unstable",
       "sid": 20011
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toastDone",
+      "status": "unstable",
       "sid": 20012
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toastDone/toastStatus",
+      "status": "unstable",
       "sid": 20013
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster",
+      "status": "unstable",
       "sid": 20014
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterManufacturer",
+      "status": "unstable",
       "sid": 20015
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterModelNumber",
+      "status": "unstable",
       "sid": 20016
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterStatus",
+      "status": "unstable",
       "sid": 20017
     }
   ]

--- a/test/test_sid/test-20-expected-ieee802-dot1q-psfp@2020-07-07.sid
+++ b/test/test_sid/test-20-expected-ieee802-dot1q-psfp@2020-07-07.sid
@@ -1,251 +1,299 @@
 {
   "assignment-ranges": [
     {
-      "entry-point": 60000, 
+      "entry-point": 60000,
       "size": 100
     }
-  ], 
-  "module-name": "ieee802-dot1q-psfp", 
-  "module-revision": "2020-07-07", 
+  ],
+  "module-name": "ieee802-dot1q-psfp",
+  "module-revision": "2020-07-07",
   "items": [
     {
-      "namespace": "module", 
-      "identifier": "ieee802-dot1q-psfp", 
+      "namespace": "module",
+      "identifier": "ieee802-dot1q-psfp",
+      "status": "unstable",
       "sid": 60000
-    }, 
+    },
     {
-      "namespace": "feature", 
-      "identifier": "psfp", 
+      "namespace": "feature",
+      "identifier": "psfp",
+      "status": "unstable",
       "sid": 60001
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time",
+      "status": "unstable",
       "sid": 60002
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time/nanoseconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time/nanoseconds",
+      "status": "unstable",
       "sid": 60003
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time/seconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-base-time/seconds",
+      "status": "unstable",
       "sid": 60004
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list",
+      "status": "unstable",
       "sid": 60005
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry",
+      "status": "unstable",
       "sid": 60006
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/gate-state-value", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/gate-state-value",
+      "status": "unstable",
       "sid": 60007
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/index", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/index",
+      "status": "unstable",
       "sid": 60008
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/interval-octet-max", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/interval-octet-max",
+      "status": "unstable",
       "sid": 60009
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/ipv-spec", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/ipv-spec",
+      "status": "unstable",
       "sid": 60010
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/operation-name", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/operation-name",
+      "status": "unstable",
       "sid": 60011
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/time-interval-value", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-control-list/gate-control-entry/time-interval-value",
+      "status": "unstable",
       "sid": 60012
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time",
+      "status": "unstable",
       "sid": 60013
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time-extension", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time-extension",
+      "status": "unstable",
       "sid": 60014
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time/denominator", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time/denominator",
+      "status": "unstable",
       "sid": 60015
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time/numerator", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:admin-cycle-time/numerator",
+      "status": "unstable",
       "sid": 60016
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change",
+      "status": "unstable",
       "sid": 60017
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-error", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-error",
+      "status": "unstable",
       "sid": 60018
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time",
+      "status": "unstable",
       "sid": 60019
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time/nanoseconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time/nanoseconds",
+      "status": "unstable",
       "sid": 60020
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time/seconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-change-time/seconds",
+      "status": "unstable",
       "sid": 60021
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-pending", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:config-pending",
+      "status": "unstable",
       "sid": 60022
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:current-time", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:current-time",
+      "status": "unstable",
       "sid": 60023
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:current-time/nanoseconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:current-time/nanoseconds",
+      "status": "unstable",
       "sid": 60024
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:current-time/seconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:current-time/seconds",
+      "status": "unstable",
       "sid": 60025
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-octets-exceeded", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-octets-exceeded",
+      "status": "unstable",
       "sid": 60026
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-octets-exceeded-enable", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-octets-exceeded-enable",
+      "status": "unstable",
       "sid": 60027
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-to-invalid-rx", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-to-invalid-rx",
+      "status": "unstable",
       "sid": 60028
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-to-invalid-rx-enable", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:gate-closed-due-to-invalid-rx-enable",
+      "status": "unstable",
       "sid": 60029
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-base-time", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-base-time",
+      "status": "unstable",
       "sid": 60030
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-base-time/nanoseconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-base-time/nanoseconds",
+      "status": "unstable",
       "sid": 60031
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-base-time/seconds", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-base-time/seconds",
+      "status": "unstable",
       "sid": 60032
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list",
+      "status": "unstable",
       "sid": 60033
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry",
+      "status": "unstable",
       "sid": 60034
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/gate-state-value", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/gate-state-value",
+      "status": "unstable",
       "sid": 60035
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/index", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/index",
+      "status": "unstable",
       "sid": 60036
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/interval-octet-max", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/interval-octet-max",
+      "status": "unstable",
       "sid": 60037
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/ipv-spec", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/ipv-spec",
+      "status": "unstable",
       "sid": 60038
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/operation-name", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/operation-name",
+      "status": "unstable",
       "sid": 60039
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/time-interval-value", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-control-list/gate-control-entry/time-interval-value",
+      "status": "unstable",
       "sid": 60040
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time",
+      "status": "unstable",
       "sid": 60041
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time-extension", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time-extension",
+      "status": "unstable",
       "sid": 60042
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time/denominator", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time/denominator",
+      "status": "unstable",
       "sid": 60043
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time/numerator", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-cycle-time/numerator",
+      "status": "unstable",
       "sid": 60044
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-gate-states", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-gate-states",
+      "status": "unstable",
       "sid": 60045
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-ipv", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:oper-ipv",
+      "status": "unstable",
       "sid": 60046
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:tick-granularity", 
+      "namespace": "data",
+      "identifier": "/ieee802-dot1q-bridge:bridges/bridge/component/ieee802-dot1q-stream-filters-gates:stream-gates/stream-gate-instance-table/ieee802-dot1q-psfp:tick-granularity",
+      "status": "unstable",
       "sid": 60047
     }
   ]

--- a/test/test_sid/test-21-expected-output.txt
+++ b/test/test_sid/test-21-expected-output.txt
@@ -1,0 +1,1 @@
+ERROR, The current SID range(s) are exhausted, 9 extra SID(s) are required, use the --sid-extra-range option to add a SID range to this YANG module.

--- a/test/test_sid/test-21-expected-output.txt
+++ b/test/test_sid/test-21-expected-output.txt
@@ -1,1 +1,26 @@
-ERROR, The current SID range(s) are exhausted, 9 extra SID(s) are required, use the --sid-extra-range option to add a SID range to this YANG module.
+Will mark unstable allocations finalized
+Finalizing unstable allocations to 2009-12-28
+  finalized toaster
+  finalized frozen-bagel
+  finalized frozen-waffle
+  finalized hash-brown
+  finalized toast-type
+  finalized wheat-bread
+  finalized white-bread
+  finalized wonder-bread
+  finalized /toaster:cancel-toast
+  finalized /toaster:make-toast
+  finalized /toaster:make-toast/input/toasterDoneness
+  finalized /toaster:make-toast/input/toasterToastType
+  finalized /toaster:toastDone
+  finalized /toaster:toastDone/toastStatus
+  finalized /toaster:toaster
+  finalized /toaster:toaster/toasterManufacturer
+  finalized /toaster:toaster/toasterModelNumber
+  finalized /toaster:toaster/toasterStatus
+  finalized croissant
+  finalized /toaster:toaster/darknessFactor
+
+File toaster@2009-12-28.sid updated
+Number of SIDs available : 25
+Number of SIDs used : 20

--- a/test/test_sid/test-21-expected-toaster@2009-12-28.sid
+++ b/test/test_sid/test-21-expected-toaster@2009-12-28.sid
@@ -1,0 +1,112 @@
+{
+  "assignment-ranges": [
+    {
+      "entry-point": 20000,
+      "size": 25
+    }
+  ],
+  "module-name": "toaster",
+  "module-revision": "2009-12-28",
+  "items": [
+    {
+      "namespace": "module",
+      "identifier": "toaster",
+      "sid": 20000
+    },
+    {
+      "namespace": "identity",
+      "identifier": "croissant",
+      "sid": 20018
+    },
+    {
+      "namespace": "identity",
+      "identifier": "frozen-bagel",
+      "sid": 20001
+    },
+    {
+      "namespace": "identity",
+      "identifier": "frozen-waffle",
+      "sid": 20002
+    },
+    {
+      "namespace": "identity",
+      "identifier": "hash-brown",
+      "sid": 20003
+    },
+    {
+      "namespace": "identity",
+      "identifier": "toast-type",
+      "sid": 20004
+    },
+    {
+      "namespace": "identity",
+      "identifier": "wheat-bread",
+      "sid": 20005
+    },
+    {
+      "namespace": "identity",
+      "identifier": "white-bread",
+      "sid": 20006
+    },
+    {
+      "namespace": "identity",
+      "identifier": "wonder-bread",
+      "sid": 20007
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:cancel-toast",
+      "sid": 20008
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:make-toast",
+      "sid": 20009
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:make-toast/input/toasterDoneness",
+      "sid": 20010
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:make-toast/input/toasterToastType",
+      "sid": 20011
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toastDone",
+      "sid": 20012
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toastDone/toastStatus",
+      "sid": 20013
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster",
+      "sid": 20014
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/darknessFactor",
+      "sid": 20019
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterManufacturer",
+      "sid": 20015
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterModelNumber",
+      "sid": 20016
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterStatus",
+      "sid": 20017
+    }
+  ]
+}

--- a/test/test_sid/test-21-expected-toaster@2009-12-28.sid
+++ b/test/test_sid/test-21-expected-toaster@2009-12-28.sid
@@ -11,102 +11,122 @@
     {
       "namespace": "module",
       "identifier": "toaster",
+      "status": "2009-12-28",
       "sid": 20000
     },
     {
       "namespace": "identity",
-      "identifier": "croissant",
-      "sid": 20018
-    },
-    {
-      "namespace": "identity",
       "identifier": "frozen-bagel",
+      "status": "2009-12-28",
       "sid": 20001
     },
     {
       "namespace": "identity",
       "identifier": "frozen-waffle",
+      "status": "2009-12-28",
       "sid": 20002
     },
     {
       "namespace": "identity",
       "identifier": "hash-brown",
+      "status": "2009-12-28",
       "sid": 20003
     },
     {
       "namespace": "identity",
       "identifier": "toast-type",
+      "status": "2009-12-28",
       "sid": 20004
     },
     {
       "namespace": "identity",
       "identifier": "wheat-bread",
+      "status": "2009-12-28",
       "sid": 20005
     },
     {
       "namespace": "identity",
       "identifier": "white-bread",
+      "status": "2009-12-28",
       "sid": 20006
     },
     {
       "namespace": "identity",
       "identifier": "wonder-bread",
+      "status": "2009-12-28",
       "sid": 20007
     },
     {
       "namespace": "data",
       "identifier": "/toaster:cancel-toast",
+      "status": "2009-12-28",
       "sid": 20008
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast",
+      "status": "2009-12-28",
       "sid": 20009
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast/input/toasterDoneness",
+      "status": "2009-12-28",
       "sid": 20010
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast/input/toasterToastType",
+      "status": "2009-12-28",
       "sid": 20011
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toastDone",
+      "status": "2009-12-28",
       "sid": 20012
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toastDone/toastStatus",
+      "status": "2009-12-28",
       "sid": 20013
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster",
+      "status": "2009-12-28",
       "sid": 20014
     },
     {
       "namespace": "data",
-      "identifier": "/toaster:toaster/darknessFactor",
-      "sid": 20019
-    },
-    {
-      "namespace": "data",
       "identifier": "/toaster:toaster/toasterManufacturer",
+      "status": "2009-12-28",
       "sid": 20015
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterModelNumber",
+      "status": "2009-12-28",
       "sid": 20016
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterStatus",
+      "status": "2009-12-28",
       "sid": 20017
+    },
+    {
+      "namespace": "identity",
+      "identifier": "croissant",
+      "status": "2009-12-28",
+      "sid": 20018
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/darknessFactor",
+      "status": "2009-12-28",
+      "sid": 20019
     }
   ]
 }

--- a/test/test_sid/test-3-expected-output.txt
+++ b/test/test_sid/test-3-expected-output.txt
@@ -2,7 +2,6 @@
 SID        Assigned to
 ---------  --------------------------------------------------
 20000      module toaster
-20018      identity croissant (New)
 20001      identity frozen-bagel
 20002      identity frozen-waffle
 20003      identity hash-brown
@@ -17,10 +16,11 @@ SID        Assigned to
 20012      data /toaster:toastDone
 20013      data /toaster:toastDone/toastStatus
 20014      data /toaster:toaster
-20019      data /toaster:toaster/darknessFactor (New)
 20015      data /toaster:toaster/toasterManufacturer
 20016      data /toaster:toaster/toasterModelNumber
 20017      data /toaster:toaster/toasterStatus
+20018      identity croissant (New)
+20019      data /toaster:toaster/darknessFactor (New)
 
 File toaster@2009-12-28.sid updated
 Number of SIDs available : 25

--- a/test/test_sid/test-3-expected-toaster@2009-12-28.sid
+++ b/test/test_sid/test-3-expected-toaster@2009-12-28.sid
@@ -11,102 +11,122 @@
     {
       "namespace": "module",
       "identifier": "toaster",
+      "status": "unstable",
       "sid": 20000
     },
     {
       "namespace": "identity",
-      "identifier": "croissant",
-      "sid": 20018
-    },
-    {
-      "namespace": "identity",
       "identifier": "frozen-bagel",
+      "status": "unstable",
       "sid": 20001
     },
     {
       "namespace": "identity",
       "identifier": "frozen-waffle",
+      "status": "unstable",
       "sid": 20002
     },
     {
       "namespace": "identity",
       "identifier": "hash-brown",
+      "status": "unstable",
       "sid": 20003
     },
     {
       "namespace": "identity",
       "identifier": "toast-type",
+      "status": "unstable",
       "sid": 20004
     },
     {
       "namespace": "identity",
       "identifier": "wheat-bread",
+      "status": "unstable",
       "sid": 20005
     },
     {
       "namespace": "identity",
       "identifier": "white-bread",
+      "status": "unstable",
       "sid": 20006
     },
     {
       "namespace": "identity",
       "identifier": "wonder-bread",
+      "status": "unstable",
       "sid": 20007
     },
     {
       "namespace": "data",
       "identifier": "/toaster:cancel-toast",
+      "status": "unstable",
       "sid": 20008
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast",
+      "status": "unstable",
       "sid": 20009
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast/input/toasterDoneness",
+      "status": "unstable",
       "sid": 20010
     },
     {
       "namespace": "data",
       "identifier": "/toaster:make-toast/input/toasterToastType",
+      "status": "unstable",
       "sid": 20011
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toastDone",
+      "status": "unstable",
       "sid": 20012
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toastDone/toastStatus",
+      "status": "unstable",
       "sid": 20013
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster",
+      "status": "unstable",
       "sid": 20014
     },
     {
       "namespace": "data",
-      "identifier": "/toaster:toaster/darknessFactor",
-      "sid": 20019
-    },
-    {
-      "namespace": "data",
       "identifier": "/toaster:toaster/toasterManufacturer",
+      "status": "unstable",
       "sid": 20015
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterModelNumber",
+      "status": "unstable",
       "sid": 20016
     },
     {
       "namespace": "data",
       "identifier": "/toaster:toaster/toasterStatus",
+      "status": "unstable",
       "sid": 20017
+    },
+    {
+      "namespace": "identity",
+      "identifier": "croissant",
+      "status": "unstable",
+      "sid": 20018
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/darknessFactor",
+      "status": "unstable",
+      "sid": 20019
     }
   ]
 }

--- a/test/test_sid/test-5-expected-ietf-constrained-voucher@2019-08-01.sid
+++ b/test/test_sid/test-5-expected-ietf-constrained-voucher@2019-08-01.sid
@@ -1,76 +1,89 @@
 {
   "assignment-ranges": [
     {
-      "entry-point": 2500, 
+      "entry-point": 2500,
       "size": 50
     }
-  ], 
-  "module-name": "ietf-constrained-voucher", 
-  "module-revision": "2019-08-01", 
+  ],
+  "module-name": "ietf-constrained-voucher",
+  "module-revision": "2019-08-01",
   "items": [
     {
-      "namespace": "module", 
-      "identifier": "ietf-constrained-voucher", 
+      "namespace": "module",
+      "identifier": "ietf-constrained-voucher",
+      "status": "unstable",
       "sid": 2500
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher",
+      "status": "unstable",
       "sid": 2501
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/assertion", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/assertion",
+      "status": "unstable",
       "sid": 2502
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/created-on", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/created-on",
+      "status": "unstable",
       "sid": 2503
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/domain-cert-revocation-checks", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/domain-cert-revocation-checks",
+      "status": "unstable",
       "sid": 2504
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/expires-on", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/expires-on",
+      "status": "unstable",
       "sid": 2505
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/idevid-issuer", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/idevid-issuer",
+      "status": "unstable",
       "sid": 2506
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/last-renewal-date", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/last-renewal-date",
+      "status": "unstable",
       "sid": 2507
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/nonce", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/nonce",
+      "status": "unstable",
       "sid": 2508
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/pinned-domain-cert", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/pinned-domain-cert",
+      "status": "unstable",
       "sid": 2509
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/pinned-domain-subject-public-key-info", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/pinned-domain-subject-public-key-info",
+      "status": "unstable",
       "sid": 2510
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/pinned-sha256-of-subject-public-key-info", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/pinned-sha256-of-subject-public-key-info",
+      "status": "unstable",
       "sid": 2511
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/ietf-constrained-voucher:voucher/serial-number", 
+      "namespace": "data",
+      "identifier": "/ietf-constrained-voucher:voucher/serial-number",
+      "status": "unstable",
       "sid": 2512
     }
   ]

--- a/test/test_sid/test-7-expected-toaster@2019-01-01.sid
+++ b/test/test_sid/test-7-expected-toaster@2019-01-01.sid
@@ -1,186 +1,220 @@
 {
   "assignment-ranges": [
     {
-      "entry-point": 20000, 
+      "entry-point": 20000,
       "size": 25
-    }, 
+    },
     {
-      "entry-point": 20100, 
+      "entry-point": 20100,
       "size": 25
     }
-  ], 
-  "module-name": "toaster", 
-  "module-revision": "2019-01-01", 
+  ],
+  "module-name": "toaster",
+  "module-revision": "2019-01-01",
   "items": [
     {
-      "namespace": "module", 
-      "identifier": "toaster", 
+      "namespace": "module",
+      "identifier": "toaster",
+      "status": "unstable",
       "sid": 20000
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "aish-merahrah", 
-      "sid": 20020
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "ajdov-kruh", 
-      "sid": 20021
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "anpan", 
-      "sid": 20022
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "appam", 
-      "sid": 20023
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "arepa", 
-      "sid": 20024
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "baba", 
-      "sid": 20100
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "bagel", 
-      "sid": 20101
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "baguette", 
-      "sid": 20102
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "bakarkhani", 
-      "sid": 20103
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "bammy", 
-      "sid": 20104
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "banana-bread", 
-      "sid": 20105
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "bannock", 
-      "sid": 20106
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "bara-brith", 
-      "sid": 20107
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "brioche", 
-      "sid": 20108
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "croissant", 
-      "sid": 20018
-    }, 
-    {
-      "namespace": "identity", 
-      "identifier": "frozen-bagel", 
+      "namespace": "identity",
+      "identifier": "frozen-bagel",
+      "status": "unstable",
       "sid": 20001
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "frozen-waffle", 
+      "namespace": "identity",
+      "identifier": "frozen-waffle",
+      "status": "unstable",
       "sid": 20002
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "hash-brown", 
+      "namespace": "identity",
+      "identifier": "hash-brown",
+      "status": "unstable",
       "sid": 20003
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "toast-type", 
+      "namespace": "identity",
+      "identifier": "toast-type",
+      "status": "unstable",
       "sid": 20004
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "wheat-bread", 
+      "namespace": "identity",
+      "identifier": "wheat-bread",
+      "status": "unstable",
       "sid": 20005
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "white-bread", 
+      "namespace": "identity",
+      "identifier": "white-bread",
+      "status": "unstable",
       "sid": 20006
-    }, 
+    },
     {
-      "namespace": "identity", 
-      "identifier": "wonder-bread", 
+      "namespace": "identity",
+      "identifier": "wonder-bread",
+      "status": "unstable",
       "sid": 20007
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:cancel-toast", 
+      "namespace": "data",
+      "identifier": "/toaster:cancel-toast",
+      "status": "unstable",
       "sid": 20008
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:make-toast", 
+      "namespace": "data",
+      "identifier": "/toaster:make-toast",
+      "status": "unstable",
       "sid": 20009
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:make-toast/input/toasterDoneness", 
+      "namespace": "data",
+      "identifier": "/toaster:make-toast/input/toasterDoneness",
+      "status": "unstable",
       "sid": 20010
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:make-toast/input/toasterToastType", 
+      "namespace": "data",
+      "identifier": "/toaster:make-toast/input/toasterToastType",
+      "status": "unstable",
       "sid": 20011
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toastDone", 
+      "namespace": "data",
+      "identifier": "/toaster:toastDone",
+      "status": "unstable",
       "sid": 20012
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toastDone/toastStatus", 
+      "namespace": "data",
+      "identifier": "/toaster:toastDone/toastStatus",
+      "status": "unstable",
       "sid": 20013
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster",
+      "status": "unstable",
       "sid": 20014
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/darknessFactor", 
-      "sid": 20019
-    }, 
-    {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/toasterManufacturer", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterManufacturer",
+      "status": "unstable",
       "sid": 20015
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/toasterModelNumber", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterModelNumber",
+      "status": "unstable",
       "sid": 20016
-    }, 
+    },
     {
-      "namespace": "data", 
-      "identifier": "/toaster:toaster/toasterStatus", 
+      "namespace": "data",
+      "identifier": "/toaster:toaster/toasterStatus",
+      "status": "unstable",
       "sid": 20017
+    },
+    {
+      "namespace": "identity",
+      "identifier": "croissant",
+      "status": "unstable",
+      "sid": 20018
+    },
+    {
+      "namespace": "data",
+      "identifier": "/toaster:toaster/darknessFactor",
+      "status": "unstable",
+      "sid": 20019
+    },
+    {
+      "namespace": "identity",
+      "identifier": "aish-merahrah",
+      "status": "unstable",
+      "sid": 20020
+    },
+    {
+      "namespace": "identity",
+      "identifier": "ajdov-kruh",
+      "status": "unstable",
+      "sid": 20021
+    },
+    {
+      "namespace": "identity",
+      "identifier": "anpan",
+      "status": "unstable",
+      "sid": 20022
+    },
+    {
+      "namespace": "identity",
+      "identifier": "appam",
+      "status": "unstable",
+      "sid": 20023
+    },
+    {
+      "namespace": "identity",
+      "identifier": "arepa",
+      "status": "unstable",
+      "sid": 20024
+    },
+    {
+      "namespace": "identity",
+      "identifier": "baba",
+      "status": "unstable",
+      "sid": 20100
+    },
+    {
+      "namespace": "identity",
+      "identifier": "bagel",
+      "status": "unstable",
+      "sid": 20101
+    },
+    {
+      "namespace": "identity",
+      "identifier": "baguette",
+      "status": "unstable",
+      "sid": 20102
+    },
+    {
+      "namespace": "identity",
+      "identifier": "bakarkhani",
+      "status": "unstable",
+      "sid": 20103
+    },
+    {
+      "namespace": "identity",
+      "identifier": "bammy",
+      "status": "unstable",
+      "sid": 20104
+    },
+    {
+      "namespace": "identity",
+      "identifier": "banana-bread",
+      "status": "unstable",
+      "sid": 20105
+    },
+    {
+      "namespace": "identity",
+      "identifier": "bannock",
+      "status": "unstable",
+      "sid": 20106
+    },
+    {
+      "namespace": "identity",
+      "identifier": "bara-brith",
+      "status": "unstable",
+      "sid": 20107
+    },
+    {
+      "namespace": "identity",
+      "identifier": "brioche",
+      "status": "unstable",
+      "sid": 20108
     }
   ]
 }


### PR DESCRIPTION
1. added new item attribute "status", which may be "unstable" or a module_revision.
2. When --sid-finalize is set, then write all items that are "unstable" out with a provide module_revision.

More and more, perhaps "unstable" should be "provisional"
