### PR TITLE
check_update does not validate 'when' constraints for YANG 1.1 models

### DIFF
--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -534,7 +534,7 @@ def chk_when(old, new, ctx):
         if len(newwhen) == 0:
             # this is good; maybe some old whens were removed
             return
-    elif len(oldwhen) == 0:
+    if len(oldwhen) == 0:
         for neww in newwhen:
             err_add(ctx.errors, neww.pos, 'CHK_NEW_WHEN', ())
     else:

--- a/test/test_update/expect/j.out
+++ b/test/test_update/expect/j.out
@@ -1,1 +1,3 @@
 j@2014-04-01.yang:9: error: CHK_ENUM_VALUE_CHANGED_v1.1
+j@2014-04-01.yang:14: error: CHK_NEW_WHEN
+j@2014-04-01.yang:18: warning: CHK_UNDECIDED_WHEN

--- a/test/test_update/j.yang
+++ b/test/test_update/j.yang
@@ -12,5 +12,9 @@ module j {
       }
     }
   }
+  leaf bar {
+    type string;
+    when "../foo = 'f'";
+  }
 }
 

--- a/test/test_update/j@2014-04-01.yang
+++ b/test/test_update/j@2014-04-01.yang
@@ -11,6 +11,11 @@ module j {
         value 2;
       }
     }
+    when "../bar = 'bar'";
+  }
+  leaf bar {
+    type string;
+    when "../foo != 'f'";
   }
 }
 


### PR DESCRIPTION
check_update.py's chk_when() checks for newly added/changed 'when' constraints and should emit CHK_NEW_WHEN/CHK_UNDECIDED_WHEN errors.

After updating to YANG 1.1 we found that check_update does not report new/changed when constraints properly.

This PR includes a simple fix to chk_when() (changes elif to if) so that errors are properly reported. It also adds a test case for a new/changed when constraints in a 1.1 model.

 **UT Results**
With UT changes but without chk_when() fix we see that the expected errors are not produced
```
trying a... ok
trying c... ok
trying f... ok
trying h... ok
trying i... ok
trying j...2,3d1
< j@2014-04-01.yang:14: error: CHK_NEW_WHEN
< j@2014-04-01.yang:18: warning: CHK_UNDECIDED_WHEN
make: *** [test] Error 1
```

With chk_when() fix:
```
> make
trying a... ok
trying c... ok
trying f... ok
trying h... ok
trying i... ok
trying j... ok
trying k... ok
trying c+d... ok
trying c+e... ok
(venv)
```