### PR TITLE
Correct display of features and deviations within the module class for UML plugin

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -346,7 +346,7 @@ class uml_emitter:
             elif stmt.keyword == 'feature':
                 self.emit_feature(mod,stmt, fd)
             elif stmt.keyword == 'deviation':
-                self.emit_feature(mod,stmt, fd)
+                self.emit_deviation(mod,stmt, fd)
 
 
         # go down one level and search for good UML roots
@@ -662,10 +662,10 @@ class uml_emitter:
 
 
     def emit_feature(self, parent, feature, fd):
-        fd.write('%s : %s \n' %(self.full_path(parent), 'feature : ' + self.make_plantuml_keyword(feature.arg)) )
+        fd.write('%s : %s \n' %(self.full_path(parent), 'feature : ' + feature.arg) )
 
-    def emit_deviation(self, parent, feature, fd):
-        fd.write('%s : %s \n' %(self.full_path(parent), 'deviation : ' + self.make_plantuml_keyword(feature.arg)) )
+    def emit_deviation(self, parent, deviation, fd):
+        fd.write('%s : %s \n' %(self.full_path(parent), 'deviation : ' + deviation.arg) )
 
     def emit_action(self, parent, action, fd):
         fd.write('%s : %s(' %(self.full_path(parent), action.arg) )


### PR DESCRIPTION
In the class representing the module in the rendered UML, the name of features defined within the module and the deviated nodes are displayed as PlantUML keywords rather than the YANG identifier for a feature or the node within the schema tree for a deviation. This change corrects these issues.
Note that the handling of deviation statements may need further improvements.