### PR TITLE
Move definition of thismod-prefix from emit_module_header() to emit() for UML plugin

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -244,6 +244,9 @@ class uml_emitter:
             self.emit_uml_header(title, fd)
 
         for module in modules:
+            pre = module.search_one('prefix')
+            if pre is not None:
+                self.thismod_prefix = pre.arg
             if not self.ctx_no_module:
                 self.emit_module_header(module, fd)
             self.emit_module_class(module, fd)
@@ -539,9 +542,6 @@ class uml_emitter:
         # pkg name for this module
         #this_pkg = self.make_plantuml_keyword(module.search_one('prefix').arg) + '.' + self.make_plantuml_keyword(module.arg)
         pkg = module.arg
-        pre = module.search_one('prefix')
-        if  pre is not None:
-            self.thismod_prefix = pre.arg
 
 
         # print package for this module and a class to represent module (notifs and rpcs)


### PR DESCRIPTION
If the 'module' in the option --uml-no, then the attribute thismod-prefix is not defined, but it is still needed regardless of whether the module is shown as package in the UML or not. 

This correction moves the definition of thismod-prefix out of the function emit_module_header() into the function emit() at the point where each module in the list of input modules is processed, immediately before the test for ctx_no_module and the call to emit_module_header().

This change can be tested by creating a UML from ietf-hardware with the option --uml-no=module.
Without this change pyang outputs the following:
```
Info: Leafref ../../component/name outside diagram. Prefix = 
Info: Leafref ../../component/name outside diagram. Prefix = 
Info: Leafref /hardware/component/name outside diagram. Prefix = 
Info: Leafref /hardware/component/state/admin-state outside diagram. Prefix = 
Info: Leafref /hardware/component/state/alarm-state outside diagram. Prefix = 
Info: Leafref /hardware/component/name outside diagram. Prefix = 
Info: Leafref /hardware/component/state/admin-state outside diagram. Prefix = 
Info: Leafref /hardware/component/state/alarm-state outside diagram. Prefix = 

Process finished with exit code 0
```
These infos in the command line output are not correct as the leafrefs do not reference any node outside of the diagram.

With this change pyang outputs the following::
```

Process finished with exit code 0
```