### PR TITLE
Correct issue with the rendering of imported modules for UML plugin

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -251,7 +251,7 @@ class uml_emitter:
                 self.emit_stmt(module, s, fd)
 
             if not self.ctx_filterfile:
-                self.post_process_module(fd)
+                self.post_process_module(module, fd)
         if not self.ctx_filterfile:
             self.post_process_diagram(fd)
 
@@ -580,12 +580,6 @@ class uml_emitter:
 
         # This package
         fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
-
-        if self.ctx_imports:
-            imports = module.search('import')
-            for i in imports:
-                mod = self.make_plantuml_keyword(i.search_one('prefix').arg) + '_' + self.make_plantuml_keyword(i.arg)
-                fd.write('%s +-- %s_%s\n' %(mod,self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
 
         includes = module.search('include')
         for inc in includes:
@@ -1080,7 +1074,7 @@ class uml_emitter:
             fd.write(augm)
 
 
-    def post_process_module(self, fd):
+    def post_process_module(self, module, fd):
 
         for base in self.baseid:
             if not base in self.identities:
@@ -1094,3 +1088,8 @@ class uml_emitter:
 
         if not self.ctx_no_module:
             fd.write("} \n\n")
+            if self.ctx_imports:
+                imports = module.search('import')
+                for i in imports:
+                    mod = self.make_plantuml_keyword(i.search_one('prefix').arg) + '_' + self.make_plantuml_keyword(i.arg)
+                    fd.write('%s +-- %s_%s\n' %(mod,self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(module.arg)))


### PR DESCRIPTION
Each imported module of a module being rendered is to be shown an empty packages with a relation from the imported package to the package representing the module. 

PlantUML does not render this correctly. This is because the relations are defined within the package representing the module being processed, causing PlantUML keyword referencing the module (package) in the relation definition to be interpreted as a new class. 

This correction moves the definitions of the relations to outside of the package, so that the keyword referencing the module (package) is interpreted as the package representing the module being processed.

This change can be verified by creating a UML from ietf-hardware without any UML-specific option specified. 
Without this change pyang outputs the following:
![image](https://github.com/mbj4668/pyang/assets/11681631/bfd197de-42e4-4667-a5cf-da943c8e513a)

With this change pyang outputs the following:
![image](https://github.com/mbj4668/pyang/assets/11681631/404930b4-38ff-4403-aab5-823e15df381b)
