### PR TITLE
Add a new option to overwrite an output file, if it already exists

### DIFF
--- a/pyang/scripts/pyang_tool.py
+++ b/pyang/scripts/pyang_tool.py
@@ -4,6 +4,7 @@ import sys
 import os
 import optparse
 import io
+import shutil
 import codecs
 from pathlib import Path
 
@@ -134,6 +135,11 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
                              dest="outfile",
                              help="Write the output to OUTFILE instead " \
                              "of stdout."),
+        optparse.make_option("-O", "--overwrite",
+                             dest="overwrite_output_file",
+                             action="store_true",
+                             default=False,
+                             help="Overwrite the output file, if it already exists."),
         optparse.make_option("-F", "--features",
                              metavar="FEATURES",
                              dest="features",
@@ -554,7 +560,11 @@ Validates the YANG module in <filename> (or stdin), and all its dependencies."""
             raise
         if tmpfile is not None:
             fd.close()
-            os.rename(tmpfile, o.outfile)
+            if not o.overwrite_output_file:
+                os.rename(tmpfile, o.outfile)
+            else:
+                shutil.copyfile(tmpfile, o.outfile)
+                os.remove(tmpfile)
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
It is sometimes annoying that pyang throws a FileExistsError if an output file already exists, such as when generating PlantUML code for a YANG module, for example, when the YANG module is updated. Currently, an existing PlantUML file has to be deleted before invoking pyang.

This pull requests adds a new option -O, --overwrite to allow the user to choose to overwrite the output file, if it already exists. By default the option is false and so this change is backwards compatible.