### PR TITLE
UML Plugin: Add new options to allow more control as to how the PlantUML code is rendered

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -822,7 +822,7 @@ class uml_emitter:
             e = t.search_one('type')
             if e.arg == 'enumeration':
                 # enum_name = self.full_path(t, False)
-                fd.write('enum \"%s\" as %s {\n' % (t.arg, self.full_path(t)))
+                fd.write('enum \"%s\" as %s {\n' %(t.arg, self.full_path(t)))
                 for enums in e.substmts[:int(self._ctx.opts.uml_max_enums)]:
                     fd.write('%s\n' %enums.arg)
                 if len(e.substmts) > int(self._ctx.opts.uml_max_enums):

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -127,7 +127,7 @@ class UMLPlugin(plugin.PyangPlugin):
                                  action="store_true",
                                  dest="uml_hide_prefix_in_package_name",
                                  default = False,
-                                 help="Do not include the module prefix in the name of packages"),
+                                 help="Do not include the module prefix within the displayed name of packages"),
             ]
         if hasattr(optparser, 'uml_opts'):
             g = optparser.uml_opts

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -99,8 +99,8 @@ class UMLPlugin(plugin.PyangPlugin):
                                  help="The maximum number of bit values to render. If set also enables rendering of bits typedefs as a 'bits' class"),
             optparse.make_option("--uml-more-values",
                                  dest="uml_more_values",
-                                 default="",
-                                 help="Change how to indicate that there are more enumerated or bits values than are shown (default:'MORE'). \nValid value: ellipsis. \nNote that ellipsis is rendered as '...'. \nExample --uml-more-values=ellipsis"),
+                                 default = "",
+                                 help="Use an alternative to 'MORE' to indicate that there are more enumerated or bits values than are shown. \nValid value: ellipsis. \nNote that ellipsis is rendered as '...'. \nExample --uml-more-values=ellipsis"),
             optparse.make_option("--uml-filter",
                                  action="store_true",
                                  dest="uml_gen_filter_file",
@@ -204,10 +204,10 @@ class uml_emitter:
     post_strings = []
     module_prefixes = []
 
-    choice_statement_symbol = ".."
-    case_statement_symbol = ".."
-    uses_statement_symbol = "-->"
-    uses_statement_label = "uses"
+    choice_relation_symbol = ".."
+    case_relation_symbol = ".."
+    uses_relation_symbol = "-->"
+    uses_relation_label = "uses"
 
     def __init__(self, ctx):
         self._ctx = ctx
@@ -262,51 +262,51 @@ class uml_emitter:
         if ctx.opts.uml_choice != "":
             if ctx.opts.uml_choice in relationship_strings:
                 if ctx.opts.uml_choice == 'generalization':
-                    self.choice_statement_symbol = "<|--"
+                    self.choice_relation_symbol = "<|--"
                 elif ctx.opts.uml_choice == 'aggregation':
-                    self.choice_statement_symbol = "o--"
+                    self.choice_relation_symbol = "o--"
                 elif ctx.opts.uml_choice == 'association':
-                    self.choice_statement_symbol = "--"
+                    self.choice_relation_symbol = "--"
                 elif ctx.opts.uml_choice == 'composition':
-                    self.choice_statement_symbol = "*--"
+                    self.choice_relation_symbol = "*--"
                 elif ctx.opts.uml_choice == 'navigable-association':
-                    self.choice_statement_symbol = "-->"
+                    self.choice_relation_symbol = "-->"
                 elif ctx.opts.uml_choice == 'realization':
-                    self.choice_statement_symbol = "<|.."
+                    self.choice_relation_symbol = "<|.."
             else:
                 sys.stderr.write("\"%s\" no valid argument to --uml-choice=...,  valid arguments (one only): %s \n" %(ctx.opts.uml_choice, relationship_strings))
         if ctx.opts.uml_case != "":
             if ctx.opts.uml_case in relationship_strings:
                 if ctx.opts.uml_case == 'generalization':
-                    self.case_statement_symbol = "<|--"
+                    self.case_relation_symbol = "<|--"
                 elif ctx.opts.uml_case == 'aggregation':
-                    self.case_statement_symbol = "o--"
+                    self.case_relation_symbol = "o--"
                 elif ctx.opts.uml_case == 'association':
-                    self.case_statement_symbol = "--"
+                    self.case_relation_symbol = "--"
                 elif ctx.opts.uml_case == 'composition':
-                    self.case_statement_symbol = "*--"
+                    self.case_relation_symbol = "*--"
                 elif ctx.opts.uml_case == 'navigable-association':
-                    self.case_statement_symbol = "-->"
+                    self.case_relation_symbol = "-->"
                 elif ctx.opts.uml_case == 'realization':
-                    self.case_statement_symbol = "<|.."
+                    self.case_relation_symbol = "<|.."
             else:
                 sys.stderr.write("\"%s\" no valid argument to --uml-case=...,  valid arguments (one only): %s \n" %(ctx.opts.uml_case, relationship_strings))
         uses_strings = ("aggregation", "association", "composition", "dependency", "generalization", "realization")
         if ctx.opts.uml_uses != "":
             if ctx.opts.uml_uses in uses_strings:
                 if ctx.opts.uml_uses == 'generalization':
-                    self.uses_statement_symbol = "<|--"
+                    self.uses_relation_symbol = "<|--"
                 elif ctx.opts.uml_uses == 'aggregation':
-                    self.uses_statement_symbol = "o--"
+                    self.uses_relation_symbol = "o--"
                 elif ctx.opts.uml_uses == 'association':
-                    self.uses_statement_symbol = "--"
+                    self.uses_relation_symbol = "--"
                 elif ctx.opts.uml_uses == 'composition':
-                    self.uses_statement_symbol = "*--"
+                    self.uses_relation_symbol = "*--"
                 elif ctx.opts.uml_uses == 'dependency':
-                    self.uses_statement_symbol = "..>"
-                    self.uses_statement_label = "<<uses>>"
+                    self.uses_relation_symbol = "..>"
+                    self.uses_relation_label = "<<uses>>"
                 elif ctx.opts.uml_uses == 'realization':
-                    self.uses_statement_symbol = "<|.."
+                    self.uses_relation_symbol = "<|.."
             else:
                 sys.stderr.write("\"%s\" no valid argument to --uml-uses=...,  valid arguments (one only): %s \n" %(ctx.opts.uml_uses, uses_strings))
 
@@ -434,7 +434,7 @@ class uml_emitter:
         elif stmt.keyword == 'choice':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<choice>> \n' % (self.full_display_path(stmt), self.full_path(stmt)))
-                fd.write('%s %s %s : choice \n' % (self.full_path(mod), self.choice_statement_symbol, self.full_path(stmt)))
+                fd.write('%s %s %s : choice \n' % (self.full_path(mod), self.choice_relation_symbol, self.full_path(stmt)))
             # sys.stderr.write('in choice %s \n', self.full_path(mod))
             for children in stmt.substmts:
                 self.emit_child_stmt(stmt, children, fd)
@@ -442,7 +442,7 @@ class uml_emitter:
         elif stmt.keyword == 'case':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s \n' %(self.full_display_path(stmt), self.full_path(stmt)))
-                fd.write('%s %s %s  : choice\n' % (self.full_path(mod), self.case_statement_symbol, self.full_path(stmt)))
+                fd.write('%s %s %s  : choice\n' % (self.full_path(mod), self.case_relation_symbol, self.full_path(stmt)))
             # sys.stderr.write('in case %s \n', full_path(mod))
             for children in mod.substmts:
                 self.emit_child_stmt(stmt, children, fd)
@@ -481,7 +481,7 @@ class uml_emitter:
             # create fake parent statement.keyword = 'case' statement.arg = node.arg
             newparent = statements.Statement(parent, parent, None, 'case', node.arg)
             fd.write('class \"%s\" as %s <<case>> \n' % (node.arg, self.full_path(newparent)))
-            fd.write('%s %s %s : choice %s\n' % (self.full_path(parent), self.case_statement_symbol, self.full_path(newparent), node.parent.arg))
+            fd.write('%s %s %s : choice %s\n' % (self.full_path(parent), self.case_relation_symbol, self.full_path(newparent), node.parent.arg))
 
             parent = newparent
 
@@ -503,7 +503,7 @@ class uml_emitter:
         elif node.keyword == 'choice':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<choice>> \n' % (self.full_display_path(node), self.full_path(node)))
-                fd.write('%s %s %s : choice \n' % (self.full_path(parent), self.choice_statement_symbol, self.full_path(node)))
+                fd.write('%s %s %s : choice \n' % (self.full_path(parent), self.choice_relation_symbol, self.full_path(node)))
             if cont:
                 for children in node.substmts:
                     # try pointing to parent
@@ -513,7 +513,7 @@ class uml_emitter:
             # sys.stderr.write('in case \n')
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<case>>\n' %(self.full_display_path(node), self.full_path(node)))
-                fd.write('%s %s %s  : choice %s\n' % (self.full_path(parent), self.case_statement_symbol, self.full_path(node), node.parent.arg))
+                fd.write('%s %s %s  : choice %s\n' % (self.full_path(parent), self.case_relation_symbol, self.full_path(node), node.parent.arg))
 
             if cont:
                 for children in node.substmts:
@@ -1191,7 +1191,7 @@ class uml_emitter:
         if self.ctx_uses:
             for p,u in self.uses:
                 try:
-                    fd.write('%s %s %s : %s \n' % (p, self.uses_statement_symbol, self.groupings[u], self.uses_statement_label))
+                    fd.write('%s %s %s : %s \n' % (p, self.uses_relation_symbol, self.groupings[u], self.uses_relation_label))
                 except KeyError: # grouping in imported module, TODO correct paths
                     # Grouping in other module, use red...
                     # fd.write('class \"%s\" as %s << (G,Red) grouping>>\n' %(self.uses_as_string[u], self.make_plantuml_keyword(self.uses_as_string[u])))

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -116,11 +116,15 @@ class UMLPlugin(plugin.PyangPlugin):
             optparse.make_option("--uml-choice",
                                  dest="uml_choice",
                                  default = "",
-                                 help="Change how the relationship between a container or list data node and a choice is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable, realization"),
+                                 help="Change how the choice statement is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable-association, realization"),
             optparse.make_option("--uml-case",
                                  dest="uml_case",
                                  default = "",
-                                 help="Change how the relationship between a choice and its cases is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable, realization"),
+                                 help="Change how case statement is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable-association, realization"),
+            optparse.make_option("--uml-uses",
+                                 dest="uml_uses",
+                                 default = "",
+                                 help="Change how the uses statement is rendered (default: navigable association). \nValid values are one of: aggregation, composition, dependency. generalization, realization. \nThis option has no effect if option --uml-inline-groupings is selected "),
             optparse.make_option("--uml-hide-prefix-in-package-names",
                                  action="store_true",
                                  dest="uml_hide_prefix_in_package_names",
@@ -205,8 +209,10 @@ class uml_emitter:
     post_strings = []
     module_prefixes = []
 
-    symbol_node_to_choice = ".."
-    symbol_choice_to_case = ".."
+    choice_statement_symbol = ".."
+    case_statement_symbol = ".."
+    uses_statement_symbol = "-->"
+    uses_statement_label = "uses"
 
     def __init__(self, ctx):
         self._ctx = ctx
@@ -260,35 +266,53 @@ class uml_emitter:
         if ctx.opts.uml_choice != "":
             if ctx.opts.uml_choice in relationship_strings:
                 if ctx.opts.uml_choice == 'generalization':
-                    self.symbol_node_to_choice = "<|--"
+                    self.choice_statement_symbol = "<|--"
                 elif ctx.opts.uml_choice == 'aggregation':
-                    self.symbol_node_to_choice = "o--"
+                    self.choice_statement_symbol = "o--"
                 elif ctx.opts.uml_choice == 'association':
-                    self.symbol_node_to_choice = "--"
+                    self.choice_statement_symbol = "--"
                 elif ctx.opts.uml_choice == 'composition':
-                    self.symbol_node_to_choice = "*--"
+                    self.choice_statement_symbol = "*--"
                 elif ctx.opts.uml_choice == 'navigable-association':
-                    self.symbol_node_to_choice = "-->"
+                    self.choice_statement_symbol = "-->"
                 elif ctx.opts.uml_choice == 'realization':
-                    self.symbol_node_to_choice = "<|.."
+                    self.choice_statement_symbol = "<|.."
             else:
-                sys.stderr.write("\"%s\" not a valid argument to --uml-case=...,  valid arguments are (one only): %s \n" %(ctx.opts.uml_choice, relationship_strings))
+                sys.stderr.write("\"%s\" not a valid argument to --uml-choice,  valid arguments are (one only): %s \n" %(ctx.opts.uml_choice, relationship_strings))
         if ctx.opts.uml_case != "":
             if ctx.opts.uml_case in relationship_strings:
                 if ctx.opts.uml_case == 'generalization':
-                    self.symbol_choice_to_case = "<|--"
+                    self.case_statement_symbol = "<|--"
                 elif ctx.opts.uml_case == 'aggregation':
-                    self.symbol_choice_to_case = "o--"
+                    self.case_statement_symbol = "o--"
                 elif ctx.opts.uml_case == 'association':
-                    self.symbol_choice_to_case = "--"
+                    self.case_statement_symbol = "--"
                 elif ctx.opts.uml_case == 'composition':
-                    self.symbol_choice_to_case = "*--"
+                    self.case_statement_symbol = "*--"
                 elif ctx.opts.uml_case == 'navigable-association':
-                    self.symbol_choice_to_case = "-->"
+                    self.case_statement_symbol = "-->"
                 elif ctx.opts.uml_case == 'realization':
-                    self.symbol_choice_to_case = "<|.."
+                    self.case_statement_symbol = "<|.."
             else:
-                sys.stderr.write("\"%s\" not a valid argument to --uml-case=...,  valid arguments are (one only): %s \n" %(ctx.opts.uml_case, relationship_strings))
+                sys.stderr.write("\"%s\" not a valid argument to --uml-case,  valid arguments are (one only): %s \n" %(ctx.opts.uml_case, uses_strings))
+        uses_strings = ("aggregation", "association", "composition", "dependency", "generalization", "realization")
+        if ctx.opts.uml_uses != "":
+            if ctx.opts.uml_uses in uses_strings:
+                if ctx.opts.uml_uses == 'generalization':
+                    self.uses_statement_symbol = "<|--"
+                elif ctx.opts.uml_uses == 'aggregation':
+                    self.uses_statement_symbol = "o--"
+                elif ctx.opts.uml_uses == 'association':
+                    self.uses_statement_symbol = "--"
+                elif ctx.opts.uml_uses == 'composition':
+                    self.uses_statement_symbol = "*--"
+                elif ctx.opts.uml_uses == 'dependency':
+                    self.uses_statement_symbol = "..>"
+                    self.uses_statement_label = "<<uses>>"
+                elif ctx.opts.uml_uses == 'realization':
+                    self.uses_statement_symbol = "<|.."
+            else:
+                sys.stderr.write("\"%s\" not a valid argument to --uml-uses,  valid arguments are (one only): %s \n" %(ctx.opts.uml_uses, uses_strings))
 
         self.ctx_filterfile = ctx.opts.uml_gen_filter_file
 
@@ -414,7 +438,7 @@ class uml_emitter:
         elif stmt.keyword == 'choice':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<choice>> \n' % (self.full_display_path(stmt), self.full_path(stmt)))
-                fd.write('%s %s %s : choice \n' % (self.full_path(mod), self.symbol_node_to_choice, self.full_path(stmt)))
+                fd.write('%s %s %s : choice \n' % (self.full_path(mod), self.choice_statement_symbol, self.full_path(stmt)))
             # sys.stderr.write('in choice %s \n', self.full_path(mod))
             for children in stmt.substmts:
                 self.emit_child_stmt(stmt, children, fd)
@@ -422,7 +446,7 @@ class uml_emitter:
         elif stmt.keyword == 'case':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s \n' %(self.full_display_path(stmt), self.full_path(stmt)))
-                fd.write('%s %s %s  : choice\n' % (self.full_path(mod), self.symbol_choice_to_case, self.full_path(stmt)))
+                fd.write('%s %s %s  : choice\n' % (self.full_path(mod), self.case_statement_symbol, self.full_path(stmt)))
             # sys.stderr.write('in case %s \n', full_path(mod))
             for children in mod.substmts:
                 self.emit_child_stmt(stmt, children, fd)
@@ -461,7 +485,7 @@ class uml_emitter:
             # create fake parent statement.keyword = 'case' statement.arg = node.arg
             newparent = statements.Statement(parent, parent, None, 'case', node.arg)
             fd.write('class \"%s\" as %s <<case>> \n' % (node.arg, self.full_path(newparent)))
-            fd.write('%s %s %s : choice %s\n' % (self.full_path(parent), self.symbol_choice_to_case, self.full_path(newparent), node.parent.arg))
+            fd.write('%s %s %s : choice %s\n' % (self.full_path(parent), self.case_statement_symbol, self.full_path(newparent), node.parent.arg))
 
             parent = newparent
 
@@ -483,7 +507,7 @@ class uml_emitter:
         elif node.keyword == 'choice':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<choice>> \n' % (self.full_display_path(node), self.full_path(node)))
-                fd.write('%s %s %s : choice \n' % (self.full_path(parent), self.symbol_node_to_choice, self.full_path(node)))
+                fd.write('%s %s %s : choice \n' % (self.full_path(parent), self.choice_statement_symbol, self.full_path(node)))
             if cont:
                 for children in node.substmts:
                     # try pointing to parent
@@ -493,7 +517,7 @@ class uml_emitter:
             # sys.stderr.write('in case \n')
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<case>>\n' %(self.full_display_path(node), self.full_path(node)))
-                fd.write('%s %s %s  : choice %s\n' % (self.full_path(parent), self.symbol_choice_to_case, self.full_path(node), node.parent.arg))
+                fd.write('%s %s %s  : choice %s\n' % (self.full_path(parent), self.case_statement_symbol, self.full_path(node), node.parent.arg))
 
             if cont:
                 for children in node.substmts:
@@ -1178,7 +1202,7 @@ class uml_emitter:
         if self.ctx_uses:
             for p,u in self.uses:
                 try:
-                    fd.write('%s --> %s : uses \n' %(p, self.groupings[u]))
+                    fd.write('%s %s %s : %s \n' % (p, self.uses_statement_symbol, self.groupings[u], self.uses_statement_label))
                 except KeyError: # grouping in imported module, TODO correct paths
                     # Grouping in other module, use red...
                     # fd.write('class \"%s\" as %s << (G,Red) grouping>>\n' %(self.uses_as_string[u], self.make_plantuml_keyword(self.uses_as_string[u])))

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -35,7 +35,7 @@ class UMLPlugin(plugin.PyangPlugin):
             optparse.make_option("--uml-classes-only",
                                  action="store_true",
                                  dest="uml_classes_only",
-                                 default = False,
+                                 default=False,
                                  help="Generate UML with classes only, no attributes "),
             optparse.make_option("--uml-split-pages",
                                  dest="uml_pages_layout",
@@ -46,85 +46,77 @@ class UMLPlugin(plugin.PyangPlugin):
             optparse.make_option("--uml-title",
                                  dest="uml_title",
                                  help="Set the title of the generated UML, including the output file name"),
-            optparse.make_option("--uml-no-title",
-                                 action="store_true",
-                                 dest="uml_no_title",
-                                 default = False,
-                                 help="Do not include a title. If --uml-title has also been specified, --uml-title will be ignored"),
             optparse.make_option("--uml-header",
                                  dest="uml_header",
                                  help="Set the page header of the generated UML"),
             optparse.make_option("--uml-footer",
                                  dest="uml_footer",
                                  help="Set the page footer of the generated UML. If not specified, a default footer will be generated"),
-            optparse.make_option("--uml-no-footer",
-                                 action="store_true",
-                                 dest="uml_no_footer",
-                                 default = False,
-                                 help="Do not include a footer. If --uml-footer has also been specified, --uml-footer will be ignored"),
             optparse.make_option("--uml-long-identifiers",
                                  action="store_true",
                                  dest="uml_longids",
-                                 default =False,
+                                 default=False,
                                  help="Use the full schema identifiers for UML class names."),
             optparse.make_option("--uml-inline-groupings",
                                  action="store_true",
                                  dest="uml_inline",
-                                 default =False,
+                                 default=False,
                                  help="Inline groupings where they are used."),
             optparse.make_option("--uml-inline-augments",
                                  action="store_true",
                                  dest="uml_inline_augments",
-                                 default =False,
+                                 default=False,
                                  help="Inline augmentations where they are used."),
             optparse.make_option("--uml-description",
                                  action="store_true",
                                  dest="uml_descr",
-                                 default =False,
+                                 default=False,
                                  help="Include description of structural nodes in diagram."),
             optparse.make_option("--uml-no",
                                  dest="uml_no",
-                                 default = "",
-                                 help="Suppress parts of the diagram. \nValid suppress values are: module, uses, leafref, identity, identityref, typedef, import, prefix, annotation, circles, stereotypes. Annotations suppresses YANG constructs represented as annotations such as config statements for containers and module info. Module suppresses module box around the diagram and module information. Prefix suppresses the the prefix in the name of packages. \nExample --uml-no=circles,stereotypes,typedef,import"),
+                                 default="",
+                                 help="Suppress parts of the diagram. \nValid suppress values are: module, uses, leafref, identity, identityref, typedef, import, annotation, circles, stereotypes, prefix, footer, title. "
+                                      "Annotations suppresses YANG constructs represented as annotations such as config statements for containers and module info. Module suppresses module box around the diagram and module information. " 
+                                      "Prefix suppresses the the prefix in the name of packages. \nIf footer or title are selected, the options --uml-footer and --uml-title respectively will be ignored. \nExample --uml-no=circles,stereotypes,typedef,import"),
             optparse.make_option("--uml-truncate",
                                  dest="uml_truncate",
-                                 default = "",
+                                 default="",
                                  help="Leafref attributes and augment elements can have long paths making the classes too wide. \nThis option will only show the tail of the path. \nExample --uml-truncate=augment,leafref"),
             optparse.make_option("--uml-max-enums",
                                  dest="uml_max_enums",
-                                 default = "3",
+                                 default="3",
                                  help="The maximum number of enumerated values to render"),
             optparse.make_option("--uml-max-bits",
                                  dest="uml_max_bits",
                                  help="The maximum number of bit values to render. If set also enables rendering of bits typedefs as a 'bits' class"),
             optparse.make_option("--uml-more-values",
                                  dest="uml_more_values",
-                                 default = "",
+                                 default="",
                                  help="Use an alternative to 'MORE' to indicate that there are more enumerated or bits values than are shown. \nValid value: ellipsis. \nNote that ellipsis is rendered as '...'. \nExample --uml-more-values=ellipsis"),
             optparse.make_option("--uml-filter",
                                  action="store_true",
                                  dest="uml_gen_filter_file",
-                                 default = False,
+                                 default=False,
                                  help="Generate filter file, comment out lines with '-' and use with option '--filter-file' to filter the UML diagram"),
             optparse.make_option("--uml-filter-file",
                                  dest="uml_filter_file",
                                  help="NOT IMPLEMENTED: Only paths in the filter file will be included in the diagram"),
             optparse.make_option("--uml-unbounded",
                                  dest="uml_unbounded",
-                                 default = "",
-                                 help="Change how the unbounded upper limit multiplicity of relationships is rendered (default: 'N'). \nValid value: *. \nExample --uml-unbounded=* "),
+                                 default="",
+                                 help="Change how the unbounded upper limit multiplicity of relationships is rendered from the default 'N'. \nValid value: *. \nExample --uml-unbounded=* "),
             optparse.make_option("--uml-choice",
                                  dest="uml_choice",
-                                 default = "",
-                                 help="Change how the choice statement is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable-association, realization. \nExample --uml-choice=composition"),
+                                 default="",
+                                 help="Change how the choice statement is rendered from the default of a dotted line. \nValid values are one of: aggregation, composition, generalization, navigable-association, realization. \nExample --uml-choice=composition"),
             optparse.make_option("--uml-case",
                                  dest="uml_case",
-                                 default = "",
-                                 help="Change how case statement is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable-association, realization. \nExample --uml-case=generalization"),
+                                 default="",
+                                 help="Change how case statement is rendered from the default of a dotted line. \nValid values are one of: aggregation, composition, generalization, navigable-association, realization. \nExample --uml-case=generalization"),
             optparse.make_option("--uml-uses",
                                  dest="uml_uses",
-                                 default = "",
-                                 help="Change how the uses statement is rendered (default: navigable association). \nValid values are one of: aggregation, composition, dependency. generalization, realization. \nThis option has no effect if option --uml-inline-groupings is selected. \nExample --uml-uses=dependency"),
+                                 default="",
+                                 help="Change how the uses statement is rendered from the default of a navigable association. \nValid values are one of: aggregation, composition, dependency. generalization, realization. \nThis option has no effect if option --uml-inline-groupings is selected. \nExample --uml-uses=dependency"),
             ]
         if hasattr(optparser, 'uml_opts'):
             g = optparser.uml_opts
@@ -165,9 +157,7 @@ class uml_emitter:
     unique = ''
     ctx_pagelayout = '1x1'
     ctx_outputdir = "img/"
-    ctx_title = None
-    ctx_no_title = False
-    ctx_no_footer = False
+    ctx_title_text = None
     ctx_fullpath = False
     ctx_classesonly = False
     ctx_description = False
@@ -180,7 +170,6 @@ class uml_emitter:
     ctx_annotations = True
     ctx_circles = True
     ctx_stereotypes = True
-    ctx_prefix = True
     ctx_truncate_leafrefs = False
     ctx_truncate_augments = False
     ctx_inline_augments = False
@@ -214,8 +203,6 @@ class uml_emitter:
         self.ctx_fullpath = ctx.opts.uml_longids
         self.ctx_description = ctx.opts.uml_descr
         self.ctx_classesonly = ctx.opts.uml_classes_only
-        self.ctx_no_title = ctx.opts.uml_no_title
-        self.ctx_no_footer = ctx.opts.uml_no_footer
         # output dir from option -D or default img/
         if ctx.opts.uml_outputdir is not None:
             self.ctx_outputdir = ctx.opts.uml_outputdir
@@ -229,7 +216,7 @@ class uml_emitter:
             self.ctx_pagelayout = ctx.opts.uml_pages_layout
 
         # Title from option -t
-        self.ctx_title = ctx.opts.uml_title
+        self.ctx_title_text = ctx.opts.uml_title
 
         self.ctx_inline_augments = ctx.opts.uml_inline_augments
 
@@ -244,8 +231,10 @@ class uml_emitter:
         self.ctx_circles = not "circles" in no
         self.ctx_stereotypes = not "stereotypes" in no
         self.ctx_prefix = not "prefix" in no
+        self.ctx_title = not "title" in no
+        self.ctx_footer = not "footer" in no
 
-        nostrings = ("module", "leafref", "uses", "annotation", "identityref", "typedef", "import", "circles", "stereotypes", "prefix")
+        nostrings = ("module", "leafref", "uses", "annotation", "identityref", "typedef", "import", "circles", "stereotypes", "prefix", "footer", "title")
         if ctx.opts.uml_no != "":
             for no_opt in no:
                 if no_opt not in nostrings:
@@ -339,8 +328,8 @@ class uml_emitter:
 
     def emit(self, modules, fd):
         title = ''
-        if self.ctx_title is not None:
-            title = self.ctx_title
+        if self.ctx_title_text is not None:
+            title = self.ctx_title_text
         else:
             for m in modules:
                 title += m.arg + '_'
@@ -616,7 +605,7 @@ class uml_emitter:
         # split into pages ? option -s
         fd.write('page %s \n' %self.ctx_pagelayout)
 
-        if not self.ctx_no_title:
+        if self.ctx_title:
             fd.write('Title %s \n' %title)
 
         if self._ctx.opts.uml_header is not None:
@@ -662,7 +651,13 @@ class uml_emitter:
         #this_pkg = self.make_plantuml_keyword(module.search_one('prefix').arg) + '.' + self.make_plantuml_keyword(module.arg)
         pkg = module.arg
 
-        fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
+        # define a empty package for the module
+        # this ensures that PlantUML knows that its keyword represents a package and not a class when referenced before the main definition of the package within the Plant UML code,
+        # e.g., by the note definition that follows below
+        if self.ctx_prefix:
+            fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
+        else:
+            fd.write('package \"%s\" as %s_%s { \n' % (pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
         fd.write('} \n')
 
         # print package for this module and a class to represent module (notifs and rpcs)
@@ -716,7 +711,7 @@ class uml_emitter:
 
 
     def emit_uml_footer(self, module, fd):
-        if not self.ctx_no_footer:
+        if self.ctx_footer:
             if self._ctx.opts.uml_footer is not None:
                 fd.write('center footer\n <size:24> %s </size>\n endfooter \n' %self._ctx.opts.uml_footer)
             else:

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -85,7 +85,7 @@ class UMLPlugin(plugin.PyangPlugin):
             optparse.make_option("--uml-no",
                                  dest="uml_no",
                                  default = "",
-                                 help="Suppress parts of the diagram. \nValid suppress values are: module, uses, leafref, identity, identityref, typedef, import, annotation, circles, stereotypes. Annotations suppresses YANG constructs represented as annotations such as config statements for containers and module info. Module suppresses module box around the diagram and module information. \nExample --uml-no=circles,stereotypes,typedef,import"),
+                                 help="Suppress parts of the diagram. \nValid suppress values are: module, uses, leafref, identity, identityref, typedef, import, prefix, annotation, circles, stereotypes. Annotations suppresses YANG constructs represented as annotations such as config statements for containers and module info. Module suppresses module box around the diagram and module information. Prefix suppresses the the prefix in the name of packages. \nExample --uml-no=circles,stereotypes,typedef,import"),
             optparse.make_option("--uml-truncate",
                                  dest="uml_truncate",
                                  default = "",
@@ -125,11 +125,6 @@ class UMLPlugin(plugin.PyangPlugin):
                                  dest="uml_uses",
                                  default = "",
                                  help="Change how the uses statement is rendered (default: navigable association). \nValid values are one of: aggregation, composition, dependency. generalization, realization. \nThis option has no effect if option --uml-inline-groupings is selected. \nExample --uml-uses=dependency"),
-            optparse.make_option("--uml-no-package-prefix",
-                                 action="store_true",
-                                 dest="uml_no_package_prefix",
-                                 default = False,
-                                 help="Do not include the module prefix within the displayed name of packages"),
             ]
         if hasattr(optparser, 'uml_opts'):
             g = optparser.uml_opts
@@ -185,13 +180,13 @@ class uml_emitter:
     ctx_annotations = True
     ctx_circles = True
     ctx_stereotypes = True
+    ctx_prefix = True
     ctx_truncate_leafrefs = False
     ctx_truncate_augments = False
     ctx_inline_augments = False
     ctx_no_module = False
     ctx_unbounded_maxelem = "N"
     ctx_more_string = "MORE"
-    ctx_no_package_prefix = False
 
     ctx_filterfile = False
     ctx_usefilterfile = None
@@ -248,8 +243,9 @@ class uml_emitter:
         self.ctx_imports = not "import" in no
         self.ctx_circles = not "circles" in no
         self.ctx_stereotypes = not "stereotypes" in no
+        self.ctx_prefix = not "prefix" in no
 
-        nostrings = ("module", "leafref", "uses", "annotation", "identityref", "typedef", "import", "circles", "stereotypes")
+        nostrings = ("module", "leafref", "uses", "annotation", "identityref", "typedef", "import", "circles", "stereotypes", "prefix")
         if ctx.opts.uml_no != "":
             for no_opt in no:
                 if no_opt not in nostrings:
@@ -294,7 +290,7 @@ class uml_emitter:
                 elif ctx.opts.uml_case == 'realization':
                     self.case_statement_symbol = "<|.."
             else:
-                sys.stderr.write("\"%s\" no valid argument to --uml-case=...,  valid arguments (one only): %s \n" %(ctx.opts.uml_case, uses_strings))
+                sys.stderr.write("\"%s\" no valid argument to --uml-case=...,  valid arguments (one only): %s \n" %(ctx.opts.uml_case, relationship_strings))
         uses_strings = ("aggregation", "association", "composition", "dependency", "generalization", "realization")
         if ctx.opts.uml_uses != "":
             if ctx.opts.uml_uses in uses_strings:
@@ -319,7 +315,6 @@ class uml_emitter:
         self.ctx_truncate_augments = "augment" in ctx.opts.uml_truncate.split(",")
         self.ctx_truncate_leafrefs = "leafref" in ctx.opts.uml_truncate.split(",")
         self.ctx_no_module = "module" in no
-        self.ctx_no_package_prefix = ctx.opts.uml_no_package_prefix
 
         truncatestrings = ("augment", "leafref")
         if ctx.opts.uml_truncate != "":
@@ -635,10 +630,10 @@ class uml_emitter:
                 #fd.write('package %s.%s \n' %(pre, pkg))
                 pre = i.search_one('prefix').arg
                 pkg = i.arg
-                if self.ctx_no_package_prefix :
-                    fd.write('package \"%s\" as %s_%s { \n' % (pkg, self.make_plantuml_keyword(pre),self.make_plantuml_keyword(pkg)))
+                if self.ctx_prefix :
+                    fd.write('package \"%s:%s\" as %s_%s { \n' % (pre, pkg, self.make_plantuml_keyword(pre), self.make_plantuml_keyword(pkg)))
                 else:
-                    fd.write('package \"%s:%s\" as %s_%s { \n' %(pre, pkg, self.make_plantuml_keyword(pre), self.make_plantuml_keyword(pkg)))
+                    fd.write('package \"%s\" as %s_%s { \n' % (pkg, self.make_plantuml_keyword(pre),self.make_plantuml_keyword(pkg)))
 
                 # search for augments and place them in correct package
                 ## augments = module.search('augment')
@@ -703,10 +698,10 @@ class uml_emitter:
             fd.write('\n')
 
         # This package
-        if self.ctx_no_package_prefix:
-            fd.write('package \"%s\" as %s_%s { \n' %(pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
-        else:
+        if self.ctx_prefix:
             fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
+        else:
+            fd.write('package \"%s\" as %s_%s { \n' %(pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
 
         if self.ctx_imports:
             imports = module.search('import')

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -112,18 +112,18 @@ class UMLPlugin(plugin.PyangPlugin):
             optparse.make_option("--uml-unbounded-multiplicity",
                                  dest="uml_unbounded_multiplicity",
                                  default = "",
-                                 help="Change how the unbounded upper limit multiplicity of relationships is rendered from the default of 'N'. \nValid values are one of: *."),
-            optparse.make_option("--uml-node-choice",
-                                 dest="uml_node_choice",
+                                 help="Change how the unbounded upper limit multiplicity of relationships is rendered (default: 'N'). \nValid values are one of: *."),
+            optparse.make_option("--uml-choice",
+                                 dest="uml_choice",
                                  default = "",
-                                 help="Selects how to render the relationship between a container or list and a choice. \nValid values are one of: aggregation, composition, dependency, generalization, realization (default dependency)"),
-            optparse.make_option("--uml-choice-case",
-                                 dest="uml_choice_case",
+                                 help="Change how the relationship between a container or list data node and a choice is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable, realization"),
+            optparse.make_option("--uml-case",
+                                 dest="uml_case",
                                  default = "",
-                                 help="Selects how to render the relationship between a choice and its cases. \nValid values are one of: aggregation, composition, dependency, generalization, realization (default dependency)"),
-            optparse.make_option("--uml-hide-prefix-in-package-name",
+                                 help="Change how the relationship between a choice and its cases is rendered (default: dotted line). \nValid values are one of: aggregation, composition, generalization, navigable, realization"),
+            optparse.make_option("--uml-hide-prefix-in-package-names",
                                  action="store_true",
-                                 dest="uml_hide_prefix_in_package_name",
+                                 dest="uml_hide_prefix_in_package_names",
                                  default = False,
                                  help="Do not include the module prefix within the displayed name of packages"),
             ]
@@ -186,11 +186,8 @@ class uml_emitter:
     ctx_inline_augments = False
     ctx_no_module = False
     ctx_unbounded_maxelem = "N"
-    ctx_relationship_node_choice = "dependency"
-    ctx_relationship_choice_case = "dependency"
-    ctx_no_circles = False
     ctx_more_string = "MORE"
-    ctx_hide_prefix_in_package_name = False
+    ctx_hide_prefix_in_package_names = False
 
     ctx_filterfile = False
     ctx_usefilterfile = None
@@ -259,43 +256,46 @@ class uml_emitter:
             else:
                 sys.stderr.write("\"%s\" not a valid argument to --uml-unbounded-multiplcity, valid arguments are (one only): %s \n" %(ctx.opts.uml_unbounded_multiplicity, alt_unbounded_multiplicity_strings))
 
-        relationship_strings = ("aggregation", "composition", "dependency", "generalization", "realization")
-        if ctx.opts.uml_node_choice != "":
-            if ctx.opts.uml_node_choice in relationship_strings:
-                self.ctx_relationship_node_choice = ctx.opts.uml_node_choice
+        relationship_strings = ("aggregation", "association", "composition", "generalization", "navigable-association", "realization")
+        if ctx.opts.uml_choice != "":
+            if ctx.opts.uml_choice in relationship_strings:
+                if ctx.opts.uml_choice == 'generalization':
+                    self.symbol_node_to_choice = "<|--"
+                elif ctx.opts.uml_choice == 'aggregation':
+                    self.symbol_node_to_choice = "o--"
+                elif ctx.opts.uml_choice == 'association':
+                    self.symbol_node_to_choice = "--"
+                elif ctx.opts.uml_choice == 'composition':
+                    self.symbol_node_to_choice = "*--"
+                elif ctx.opts.uml_choice == 'navigable-association':
+                    self.symbol_node_to_choice = "-->"
+                elif ctx.opts.uml_choice == 'realization':
+                    self.symbol_node_to_choice = "<|.."
             else:
-                sys.stderr.write("\"%s\" not a valid argument to --uml-case=...,  valid arguments are (one only): %s \n" %(ctx.opts.uml_node_choice, relationship_strings))
-
-        if self.ctx_relationship_node_choice == 'generalization':
-            self.symbol_node_to_choice = "<|--"
-        elif self.ctx_relationship_node_choice == 'aggregation':
-            self.symbol_node_to_choice = "o--"
-        elif self.ctx_relationship_node_choice == 'composition':
-            self.symbol_node_to_choice = "*--"
-        elif self.ctx_relationship_node_choice == 'realization':
-            self.symbol_node_to_choice = "<|.."
-
-        if ctx.opts.uml_choice_case != "":
-            if ctx.opts.uml_choice_case in relationship_strings:
-                self.ctx_relationship_choice_case = ctx.opts.uml_choice_case
+                sys.stderr.write("\"%s\" not a valid argument to --uml-case=...,  valid arguments are (one only): %s \n" %(ctx.opts.uml_choice, relationship_strings))
+        if ctx.opts.uml_case != "":
+            if ctx.opts.uml_case in relationship_strings:
+                if ctx.opts.uml_case == 'generalization':
+                    self.symbol_choice_to_case = "<|--"
+                elif ctx.opts.uml_case == 'aggregation':
+                    self.symbol_choice_to_case = "o--"
+                elif ctx.opts.uml_case == 'association':
+                    self.symbol_choice_to_case = "--"
+                elif ctx.opts.uml_case == 'composition':
+                    self.symbol_choice_to_case = "*--"
+                elif ctx.opts.uml_case == 'navigable-association':
+                    self.symbol_choice_to_case = "-->"
+                elif ctx.opts.uml_case == 'realization':
+                    self.symbol_choice_to_case = "<|.."
             else:
-                sys.stderr.write("\"%s\" not a valid argument to --uml-case=...,  valid arguments are (one only): %s \n" %(ctx.opts.uml_choice_case, relationship_strings))
+                sys.stderr.write("\"%s\" not a valid argument to --uml-case=...,  valid arguments are (one only): %s \n" %(ctx.opts.uml_case, relationship_strings))
 
-        if self.ctx_relationship_choice_case == 'generalization':
-            self.symbol_choice_to_case = "<|--"
-        elif self.ctx_relationship_choice_case == 'aggregation':
-            self.symbol_choice_to_case = "o--"
-        elif self.ctx_relationship_choice_case == 'composition':
-            self.symbol_choice_to_case = "*--"
-        elif self.ctx_relationship_choice_case == 'realization':
-            self.symbol_choice_to_case = "<|.."
-            
         self.ctx_filterfile = ctx.opts.uml_gen_filter_file
 
         self.ctx_truncate_augments = "augment" in ctx.opts.uml_truncate.split(",")
         self.ctx_truncate_leafrefs = "leafref" in ctx.opts.uml_truncate.split(",")
         self.ctx_no_module = "module" in no
-        self.ctx_hide_prefix_in_package_name = ctx.opts.uml_hide_prefix_in_package_name
+        self.ctx_hide_prefix_in_package_names = ctx.opts.uml_hide_prefix_in_package_names
 
         truncatestrings = ("augment", "leafref")
         if ctx.opts.uml_truncate != "":
@@ -613,7 +613,7 @@ class uml_emitter:
                 #fd.write('package %s.%s \n' %(pre, pkg))
                 pre = i.search_one('prefix').arg
                 pkg = i.arg
-                if self.ctx_hide_prefix_in_package_name :
+                if self.ctx_hide_prefix_in_package_names :
                     fd.write('package \"%s\" as %s_%s { \n' % (pkg, self.make_plantuml_keyword(pre),self.make_plantuml_keyword(pkg)))
                 else:
                     fd.write('package \"%s:%s\" as %s_%s { \n' %(pre, pkg, self.make_plantuml_keyword(pre), self.make_plantuml_keyword(pkg)))
@@ -681,7 +681,7 @@ class uml_emitter:
             fd.write('\n')
 
         # This package
-        if self.ctx_hide_prefix_in_package_name:
+        if self.ctx_hide_prefix_in_package_names:
             fd.write('package \"%s\" as %s_%s { \n' %(pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
         else:
             fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -123,6 +123,11 @@ class UMLPlugin(plugin.PyangPlugin):
                                  dest="uml_choice_case",
                                  default = "",
                                  help="Selects how to render the relationship between a choice and its cases. \nValid values are one of: aggregation, composition, dependency, generalization, realization (default dependency)"),
+            optparse.make_option("--uml-hide-prefix-in-package-name",
+                                 action="store_true",
+                                 dest="uml_hide_prefix_in_package_name",
+                                 default = False,
+                                 help="Do not include the module prefix in the name of packages"),
             ]
         if hasattr(optparser, 'uml_opts'):
             g = optparser.uml_opts
@@ -187,6 +192,7 @@ class uml_emitter:
     ctx_relationship_choice_case = "dependency"
     ctx_no_circles = False
     ctx_more_string = "MORE"
+    ctx_hide_prefix_in_package_name = False
 
     ctx_filterfile = False
     ctx_usefilterfile = None
@@ -285,6 +291,7 @@ class uml_emitter:
         self.ctx_truncate_augments = "augment" in ctx.opts.uml_truncate.split(",")
         self.ctx_truncate_leafrefs = "leafref" in ctx.opts.uml_truncate.split(",")
         self.ctx_no_module = "module" in no
+        self.ctx_hide_prefix_in_package_name = ctx.opts.uml_hide_prefix_in_package_name
 
         truncatestrings = ("augment", "leafref")
         if ctx.opts.uml_truncate != "":
@@ -602,7 +609,10 @@ class uml_emitter:
                 #fd.write('package %s.%s \n' %(pre, pkg))
                 pre = i.search_one('prefix').arg
                 pkg = i.arg
-                fd.write('package \"%s:%s\" as %s_%s { \n' %(pre, pkg, self.make_plantuml_keyword(pre), self.make_plantuml_keyword(pkg)))
+                if self.ctx_hide_prefix_in_package_name :
+                    fd.write('package \"%s\" as %s_%s { \n' % (pkg, self.make_plantuml_keyword(pre),self.make_plantuml_keyword(pkg)))
+                else:
+                    fd.write('package \"%s:%s\" as %s_%s { \n' %(pre, pkg, self.make_plantuml_keyword(pre), self.make_plantuml_keyword(pkg)))
 
                 # search for augments and place them in correct package
                 ## augments = module.search('augment')
@@ -667,7 +677,10 @@ class uml_emitter:
             fd.write('\n')
 
         # This package
-        fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
+        if self.ctx_hide_prefix_in_package_name:
+            fd.write('package \"%s\" as %s_%s { \n' %(pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
+        else:
+            fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
 
         if self.ctx_imports:
             imports = module.search('import')

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -50,13 +50,18 @@ class UMLPlugin(plugin.PyangPlugin):
                                  action="store_true",
                                  dest="uml_no_title",
                                  default = False,
-                                 help="Do not include a title. If a title has also been specified as an option, it will be ignored."),
+                                 help="Do not include a title. If a title has also been specified as an option, it will be ignored"),
             optparse.make_option("--uml-header",
                                  dest="uml_header",
                                  help="Set the page header of the generated UML"),
             optparse.make_option("--uml-footer",
                                  dest="uml_footer",
-                                 help="Set the page footer of the generated UML"),
+                                 help="Set the page footer of the generated UML. If not specified, a default footer will be generated"),
+            optparse.make_option("--uml-no-footer",
+                                 action="store_true",
+                                 dest="uml_no_footer",
+                                 default = False,
+                                 help="Do not include a footer. If a footer has also been specified as an option, it will be ignored"),
             optparse.make_option("--uml-long-identifiers",
                                  action="store_true",
                                  dest="uml_longids",
@@ -153,6 +158,7 @@ class uml_emitter:
     ctx_outputdir = "img/"
     ctx_title = None
     ctx_no_title = False
+    ctx_no_footer = False
     ctx_fullpath = False
     ctx_classesonly = False
     ctx_description = False
@@ -198,6 +204,7 @@ class uml_emitter:
         self.ctx_description = ctx.opts.uml_descr
         self.ctx_classesonly = ctx.opts.uml_classes_only
         self.ctx_no_title = ctx.opts.uml_no_title
+        self.ctx_no_footer = ctx.opts.uml_no_footer
         self.ctx_unbound_is_star = ctx.opts.uml_unbound_is_star
         # output dir from option -D or default img/
         if ctx.opts.uml_outputdir is not None:
@@ -561,8 +568,9 @@ class uml_emitter:
 
         if not self.ctx_no_title:
             fd.write('Title %s \n' %title)
-            if self._ctx.opts.uml_header is not None:
-                fd.write('center header\n <size:48> %s </size>\n endheader \n' %self._ctx.opts.uml_header)
+
+        if self._ctx.opts.uml_header is not None:
+            fd.write('center header\n <size:48> %s </size>\n endheader \n' %self._ctx.opts.uml_header)
 
 
     def emit_module_header(self, module, fd):
@@ -659,11 +667,12 @@ class uml_emitter:
 
 
     def emit_uml_footer(self, module, fd):
-        if self._ctx.opts.uml_footer is not None:
-            fd.write('center footer\n <size:24> %s </size>\n endfooter \n' %self._ctx.opts.uml_footer)
-        else:
-            now = datetime.datetime.now()
-            fd.write('center footer\n <size:20> UML Generated : %s </size>\n endfooter \n' %now.strftime("%Y-%m-%d %H:%M"))
+        if not self.ctx_no_footer:
+            if self._ctx.opts.uml_footer is not None:
+                fd.write('center footer\n <size:24> %s </size>\n endfooter \n' %self._ctx.opts.uml_footer)
+            else:
+                now = datetime.datetime.now()
+                fd.write('center footer\n <size:20> UML Generated : %s </size>\n endfooter \n' %now.strftime("%Y-%m-%d %H:%M"))
 
         fd.write('@enduml \n')
 

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -822,7 +822,7 @@ class uml_emitter:
             e = t.search_one('type')
             if e.arg == 'enumeration':
                 # enum_name = self.full_path(t, False)
-                fd.write('enum \"%s\" as %s <<enumeration>> {\n' %(t.arg, self.full_path(t)))
+                fd.write('enum \"%s\" as %s {\n' % (t.arg, self.full_path(t)))
                 for enums in e.substmts[:int(self._ctx.opts.uml_max_enums)]:
                     fd.write('%s\n' %enums.arg)
                 if len(e.substmts) > int(self._ctx.opts.uml_max_enums):


### PR DESCRIPTION
Companies may have their own guidelines on how YANG models are rendered in UML, such as rendering the relationship from an interior node to a choice statement as composition rather than a dotted line. This pull requests adds new UML-specific options to control some aspects of the rendering of UML and extends the --uml-no option to suppress additional parts of the diagram as detailed below.

--uml-no:
Adds the following new values 
- "prefix" to suppress the use of the module prefix in the name of the package representing a module, including imported modules.
- "title", "footer" to suppress the diagram's title and footer to allow a title and/or footer to be generated in a separate include file, for example, according to a company's best practice guidelines.

--uml-max-bits:
Currently pyang renders a bits typedef as a class with the \<\<typedef\>\> stereotype. The presence of this new option enables the rendering of a bits typedef as a class with the \<\<bits\>\> stereotype and also sets the maximum number of bit values to display.

--uml-more-values:
pyang indicates that more values are present within a typedef class through the text "MORE".
This new option allows this to be changed to "..." to align with some best practices.

--uml-unbounded:
pyang indicates an unbounded upper limit of multiplicity (maxelements) using an "N". UML defines this generally using a "\*" as do many best practice guidelines. 
This new option allows the rendering of an unbounded multiplicity as a "\*" rather than an "N".

--uml-choice, --uml-case, --uml-uses:
pyang uses a dotted line relation between an interior node and a choice and between a choice and its cases and uses a navigable association to a grouping to indicate a uses statement. Some best practice guidelines and other tools use other relationships such as composition between an interior node and a choice or a dependency relationship for a uses statement.
These new options allow a user to define how the relations for choice, case and uses are rendered. If the uses statement is to be rendered as a UML dependency, the label on the relation also changes from "uses" to "\<\<uses\>\>" to indicate the type of dependency according to UML notation.

All changes are backwards compatible, that is the rendering of PlantUML code does not change unless one or more of these new options are specified.