### PR TITLE
adding --uml-skip-module, --uml-add-legend

### DIFF
--- a/pyang/__init__.py
+++ b/pyang/__init__.py
@@ -1,4 +1,4 @@
 """The pyang library for parsing, validating, and converting YANG modules"""
 
-__version__ = '2.5.3'
+__version__ = '2.5.4'
 __date__ = '2022-03-30'


### PR DESCRIPTION
When we use --uml-inline-grouping flag we can expect to ignore base modules like tailf-ncs etc, in this PR we are added new flags. 

Command: 
```sh
pyang -f uml l3vpn.yang --path=/tmp/.ncs_uml --uml-inline-groupings --uml-skip-module=tailf-ncs --uml-output-directory=.  --uml-no=module,import,annotation  --uml-add-legend 2> /dev/null
```

`--uml-add-legend` adds filenames from shared grouping - *Note: not skipping any module for this example*
Here is the legend plantUML code generated.
```
legend
Grouping data pulled from
  l3vpn.yang
  tailf-ncs-services.yang
  tailf-ncs-log.yang
endlegend
```

`--uml-skip-module=tailf-ncs` with `--uml-inline-groupings`, inline grouping adds all the grouping uses in the yang including the base service-data, plan-date and more, in the new flag we can skip entire module from inline-grouping.
Here the skip modules are kept in the {uses} as before --uml-inline-groupings flag.

Image before the `--uml-skip-module`
![image](https://github.com/mbj4668/pyang/assets/1794046/585136eb-d894-49f0-a486-5533028c0ed6)

Image with `--uml-skip-module`
![image](https://github.com/mbj4668/pyang/assets/1794046/ee62d70b-23be-4d82-a97b-ea1de6ec0a7e)


