### PR TITLE
UML Plugin: Fix dots in identifiers not being converted to underscore in PlantUML keywords

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -975,10 +975,13 @@ class uml_emitter:
 
 
     def make_plantuml_keyword(self, s):
-        #plantuml does not like -/: in identifiers, fixed :)
+        #plantuml does not like -/:. in identifiers, fixed :)
         s = s.replace('-', '_')
         s = s.replace('/', '_')
         s = s.replace(':', '_')
+        # RFC 7950 allows YANG identifiers to contain dots and dashes, so to ensure there is no chance of a clash of keywords where say identifiers 'a.b' and 'a-b' exist, use underscores for dots
+        s = s.replace('.', '__')
+
         return s
 
 

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -979,7 +979,7 @@ class uml_emitter:
         s = s.replace('-', '_')
         s = s.replace('/', '_')
         s = s.replace(':', '_')
-        # RFC 7950 allows YANG identifiers to contain dots and dashes, so to ensure there is no chance of a clash of keywords where say identifiers 'a.b' and 'a-b' exist, use underscores for dots
+        # RFC 7950 allows YANG identifiers to contain dots and dashes, so to ensure there is no chance of a clash of keywords where say identifiers 'a.b' and 'a-b' exist, use 2 underscores for dots
         s = s.replace('.', '__')
 
         return s


### PR DESCRIPTION
PlantUML does not accept dots in keywords, but the current UML plugin does not convert dots in keywords (as permitted for YANG identifiers by RFC 7950 section 6.2) to underscores in the function make_plantuml_keyword(). 

This fix replaces dots with 2 underscores to ensure there is no chance of a clash of keywords where say both the identifiers 'a.b' and 'a-b' exist.

If PlantUML code is generated from the following test module (no specific UML-specific option specified), PlantUML brings an error.

```
module test-identifier-dots {
  yang-version 1.1;
  namespace "http://www.example.com/ns/yang/test-identifier-dots";
  prefix tst-id-dots;
  revision 2023-07-17 {
    description
      "Initial revision.";
    reference
      "None.";
  }
  identity base-identity {
    description
      "Base identity for identities.";
  }
  identity a {
    base base-identity;
    description
      "...";
  }
  identity a.1 {
    base a;
    description
      "...";
  }
  identity a-1 {
    base a;
    description
      "...";
  }
  identity a.2 {
    base a;
    description
      "...";
  }
  identity a-2 {
    base a;
    description
      "...";
  }
  identity a.2-b.1 {
    base a.2;
    description
      "...";
  }
}
```
With this fix, the following UML diagram is generated:
![image](https://github.com/mbj4668/pyang/assets/11681631/4dd8df86-b117-48c8-a45a-ec21691bcec2)
