### PR TITLE
UML Plugin: Fix issues with the rendering of identities, identityrefs, typedefs, leafrefs

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -165,7 +165,9 @@ class uml_emitter:
     thismod_prefix = ''
     _ctx = None
     post_strings = []
+    end_strings = []
     module_prefixes = []
+    leafref_classes = []
 
     def __init__(self, ctx):
         self._ctx = ctx
@@ -649,12 +651,21 @@ class uml_emitter:
 
     def emit_identity(self, mod, stmt, fd):
         if self.ctx_identities:
-            self.post_strings.append('class \"%s\" as %s << (I,Silver) identity>> \n' %(self.full_display_path(stmt), self.make_plantuml_keyword(stmt.arg)))
-            self.identities.append(stmt.arg)
+            # add module prefix to ensure global uniqueness across modules
+            identity = self.thismod_prefix + ':' + stmt.arg
+            keyword = self.make_plantuml_keyword(identity)+'_identity'
+            self.post_strings.append('class \"%s\" as %s << (I,Silver) identity>> \n' %(self.full_display_path(stmt), keyword))
+            if identity not in self.identities:
+                self.identities.append(identity)
             base = stmt.search_one('base')
             if base is not None:
-                self.baseid.append(base.arg)
-                self.post_strings.append('%s <|-- %s \n' %(self.make_plantuml_keyword(base.arg), self.make_plantuml_keyword(stmt.arg)))
+                # if base does not include prefix, add prefix of current module
+                baseid = base.arg
+                if ':' not in baseid:
+                    baseid = self.thismod_prefix+':'+baseid
+                if baseid not in self.baseid:
+                    self.baseid.append(baseid)
+                self.post_strings.append('%s <|-- %s \n' %(self.make_plantuml_keyword(baseid)+'_identity', keyword))
 
 
     def emit_feature(self, parent, feature, fd):
@@ -701,18 +712,19 @@ class uml_emitter:
 
     def emit_typedef(self, m, t, fd):
         if self.ctx_typedefs:
+            keyword = self.make_plantuml_keyword(self.thismod_prefix) + '_' + self.make_plantuml_keyword(t.arg) + '_typedef'
             e = t.search_one('type')
             if e.arg == 'enumeration':
                 # enum_name = self.full_path(t, False)
-                fd.write('enum \"%s\" as %s {\n' %(t.arg, self.full_path(t)))
+                fd.write('enum \"%s\" as %s <<enumeration>> {\n' %(t.arg, keyword))
                 for enums in e.substmts[:int(self._ctx.opts.uml_max_enums)]:
                     fd.write('%s\n' %enums.arg)
                 if len(e.substmts) > int(self._ctx.opts.uml_max_enums):
                     fd.write('%s\n' %"MORE")
                 fd.write("}\n")
             else:
-                fd.write('class \"%s\" as %s << (T, YellowGreen) typedef>>\n' %(t.arg, self.make_plantuml_keyword(t.arg)))
-                fd.write('%s : %s\n' %(self.make_plantuml_keyword(t.arg), self.typestring(t)))
+                fd.write('class \"%s\" as %s << (T, YellowGreen) typedef>>\n' %(t.arg, keyword))
+                fd.write('%s : %s\n' %(keyword, self.typestring(t)))
 
 
     def emit_notif(self, module, stmt,fd):
@@ -827,23 +839,39 @@ class uml_emitter:
                 s = s.replace(')', '}')
 
                 if node.i_leafref_ptr is not None:
-                    n = node.i_leafref_ptr[0]
+                    target_node = node.i_leafref_ptr[0]
                 else:
-                    n = None
+                    target_node = None
 
-                prefix, _ = util.split_identifier(p.arg)
-                # FIXME: previous code skipped first char, possibly in error
-                prefix = self.thismod_prefix if prefix is None else prefix[1:]
+                if target_node is not None:
 
-                if n is not None:
                     if node.keyword == 'typedef':
-                        self.leafrefs.append(self.make_plantuml_keyword(node.arg) + '-->' + '"' + leafrefkey + '"' + self.full_path(n.parent) + ': ' + node.arg + '\n')
+                        source_keyword = self.make_plantuml_keyword(self.thismod_prefix) + '_' + self.make_plantuml_keyword(node.arg) + '_typedef'
                     else:
-                        self.leafrefs.append(self.full_path(node.parent) + '-->' + '"' + leafrefkey + '"' + self.full_path(n.parent) + ': ' + node.arg + '\n')
-                    if prefix not in self.module_prefixes:
-                        self.post_strings.append('class \"%s\" as %s <<leafref>> \n' %(leafrefparent, self.full_path(n.parent)))
-                        # self.post_strings.append('%s : %s\n' %(self.full_path(n.parent), leafrefkey))
-                        sys.stderr.write("Info: Leafref %s outside diagram. Prefix = %s\n" %(p.arg, prefix))
+                        source_keyword = self.full_path(node.parent)
+
+                    target_prefix, _ = util.split_identifier(leafrefkey)
+                    # FIXME: previous code skipped first char, possibly in error
+                    if target_prefix is None:
+                        target_prefix = self.thismod_prefix
+
+                    # if target node (last node in path) is located in the list of input modules, a relation to the target class can be created
+                    if target_prefix in self.module_prefixes:
+                        # if the relation is internal to this module append to leafrefs else append to end of diagram outside the scope of any input module
+                        target_keyword = self.full_path(target_node.parent)
+                        if target_prefix == self.thismod_prefix:
+                            self.leafrefs.append(source_keyword + '-->' + '"' + leafrefkey + '"' + target_keyword + ': ' + node.arg + '\n')
+                        else:
+                            self.end_strings.append(source_keyword + '-->' + '"' + leafrefkey + '"' + target_keyword + ': ' + node.arg + '\n')
+                    else:
+                        # no target within input modules, so create a class as placeholder
+                        target_keyword = self.full_path(target_node.parent) + '_leafref'
+                        # add a class to represent the target of the leafref, if not already previously created during processing of this module
+                        if target_keyword not in self.leafref_classes:
+                            self.post_strings.append('class \"%s\" as %s <<leafref>> \n' %(leafrefparent, target_keyword))
+                            self.leafref_classes.append(target_keyword)
+                        self.leafrefs.append(source_keyword + '-->' + '"' + leafrefkey + '"' + target_keyword + ': ' + node.arg + '\n')
+                        sys.stderr.write("Info: Leafref %s outside diagram. Prefix = %s\n" %(p.arg, target_prefix))
 
                 else:
                     sys.stderr.write("Info: Did not find leafref target %s\n" %p.arg)
@@ -861,7 +889,30 @@ class uml_emitter:
             if b is not None:
                 s = s + ' {' + b.arg + '}'
                 if self.ctx_identityrefs and self.ctx_identities:
-                    self.post_strings.append(self.full_path(node.parent) + '-->' + self.make_plantuml_keyword(b.arg) + ': ' + node.arg + '\n')
+                    baseid = b.arg
+                    if ':' not in baseid:
+                        # if no prefix found, it must be defined in this module, so add this module's prefix
+                        baseid = self.thismod_prefix + ':' + baseid
+
+                    if baseid not in self.baseid:
+                        self.baseid.append(baseid)
+
+                    if node.keyword == 'typedef':
+                        keyword = self.make_plantuml_keyword(self.thismod_prefix) + '_' + self.make_plantuml_keyword(node.arg) + '_typedef'
+                    else:
+                        keyword = self.full_path(node.parent)
+
+                    # add a relation to the baseid:
+                    # if baseid is defined in this module, then an identity class will have been defined in this module and
+                    # if baseid is not in an input module, then function post_process_module() will then add a placeholder class for the identity
+                    # in both the above cases the keyword will be then same
+                    # if baseid is in another input module, then an identity class will have been defined there (with the same keyword), in which case the relation must be defined outside of the module packages
+                    prefix, _ = util.split_identifier(baseid)
+                    if prefix == self.thismod_prefix or prefix not in self.module_prefixes:
+                        self.post_strings.append(keyword + '-->' + self.make_plantuml_keyword(baseid) + '_identity : ' + node.arg + '\n')
+                    else:
+                        self.end_strings.append(keyword + '-->' + self.make_plantuml_keyword(baseid) + '_identity : ' + node.arg + '\n')
+
 
         elif t.arg == 'union':
             uniontypes = t.search('type')
@@ -1054,6 +1105,7 @@ class uml_emitter:
         stmt.i_annotate_node = node
         return inthismod, node
 
+
     def post_process_diagram(self, fd):
         if self.ctx_uses:
             for p,u in self.uses:
@@ -1070,6 +1122,9 @@ class uml_emitter:
             for l in self.leafrefs:
                 fd.write(l)
 
+        for s in self.end_strings:
+            fd.write(s)
+
         # remove duplicates
         self.augments = list(set(self.augments))
         for augm in self.augments:
@@ -1079,13 +1134,19 @@ class uml_emitter:
     def post_process_module(self, module, fd):
 
         for base in self.baseid:
+            # If a base is not defined in the module, define it, if it is not in another input module
             if not base in self.identities:
-                fd.write('class \"%s\" as %s << (I,Silver) identity>> \n' %(base, self.make_plantuml_keyword(base)))
+                prefix, _ = util.split_identifier(base)
+                if prefix not in self.module_prefixes:
+                    keyword = self.make_plantuml_keyword(base) + '_identity'
+                    fd.write('class \"%s\" as %s << (I,Silver) identity>> \n' %(base, keyword))
 
         for s in self.post_strings:
             fd.write(s)
 
-        self.based = []
+        self.baseid = []
+        self.identities = []
+        self.leafref_classes = []
         self.post_strings = []
 
         if not self.ctx_no_module:


### PR DESCRIPTION
This pull request fixes issues with the rendering of identities, identities, typedefs and leafrefs and relations associated with them:
1. Fix missing stereotype \<\<enumeration\>\> on the enumeration class.
1. Fix the false identification of the source of an identityref when the source is a typedef.
1. Fix multiple identical base ids in self.baseid which result in duplicate definitions in the PlantUML code (note this has no effect on the diagram as such).
1. Fix multiple identical identities in self.identities which result in duplicate definitions in the PlantUML code (note this has no effect on the diagram as such).
1. Fix base identities from being rendered in modules in which they are not used.
    - This was caused by a typo in attribute name in the function post_process_module(), so that the list of base identities in the module being processed is not emptied before the next module is processed (self.based to self.baseid).
1. Fix an issue where bases for identityrefs are not added to self.baseid and therefore not rendered as a placeholder class, if the base is not defined within the set of input modules.
1. Fix an issue to add relations defined for identityrefs that cross between 2 input modules outside the scope of the packages representing the input modules.
    - This required adding a new attribute self.end_strings to collect such relation strings during processing of the modules and appending to the file in the function post_process_diagram().
1. Fix keyword scoping issues and clashing keywords
    - In YANG it is permitted to give the same name to a feature, identity, typedef and top-level data nodes within a single module. In addition, the same name can be used in different modules to define different features, identities, typedefs and top-level data nodes. However, the current UML plugin does not take this into account resulting in name clashes.
    - PlantUML keywords are now generated for classes representing identities and typedefs to include either an ‘_identity’ or ‘_typedef’ suffix to ensure uniqueness of keywords across typedef and identity definitions
    - The module prefix is always included when referencing identities and baseids within the UML plugin code and PlantUML keywords are always generated from prefix + name to ensure uniqueness across modules.
1. Fix name clashes with placeholder classes representing leafref targets not within the input modules
    - The suffix ‘-leafref’ is added to leafref placeholder classes to avoid the name clashes with existing class definitions.
1. Fixes an issue with identifying in which module the target node is located by augmented schemas
    - The module in which a target node is located is now identified by the prefix associated with the last node in the XPath expression.

Note that other issues need addressing in a future pull requests such as the issue where individual node prefixes within XPath expressions are not taken into account when defining keywords for data nodes which leads to issues when handling XPaths for augmentations, e.g., when 2 augmentations augment the same named node but under different module prefixes, e.g., the nodes ‘line’ in the modules bbf-fast and bbf-vdsl. Due to its impact on the existing code, this issue was not addressed with this pull request.