### PR TITLE
UML Plugin: Fix missing notifications defined in interior data nodes

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -458,6 +458,8 @@ class uml_emitter:
             elif node.keyword == 'leaf-list':
                 fd.write('%s : %s %s %s\n' %(self.full_path(parent), node.arg, '[]: ' + self.typestring(node), self.attribs(node)) )
                 self.emit_must_leaf(parent, node, fd)
+            elif node.keyword == 'notification':
+                self.emit_notif(parent, node, fd)
             elif node.keyword in ['action', ('tailf-common', 'action')]:
                 self.emit_action(parent, node, fd)
             elif node.keyword == ('tailf-common', 'callpoint'):
@@ -715,13 +717,13 @@ class uml_emitter:
                 fd.write('%s : %s\n' %(self.make_plantuml_keyword(t.arg), self.typestring(t)))
 
 
-    def emit_notif(self, module, stmt,fd):
+    def emit_notif(self, parent, node, fd):
         # ALTERNATIVE 1
         # notif as class stereotype, ugly, but easier to layout params
-        fd.write('class \"%s\" as %s << (N,#00D1B2) notification>> \n' %(self.full_display_path(stmt), self.full_path(stmt)))
-        fd.write('%s -- %s : notification \n' %(self.make_plantuml_keyword(module.arg), self.full_path(stmt)))
-        for params in stmt.substmts:
-            self.emit_child_stmt(stmt, params, fd)
+        fd.write('class \"%s\" as %s << (N,#00D1B2) notification>> \n' % (self.full_display_path(node), self.full_path(node)))
+        fd.write('%s -- %s : notification \n' % (self.make_plantuml_keyword(self.full_path(parent)), self.full_path(node)))
+        for params in node.substmts:
+            self.emit_child_stmt(node, params, fd)
 
         # ALTERNATIVE 2
         # notif as oper, better, but hard to layout params

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -346,6 +346,8 @@ class uml_emitter:
                 self.emit_action(mod, stmt,fd)
             elif stmt.keyword == 'notification':
                 self.emit_notif(mod, stmt,fd)
+                for s in stmt.substmts:
+                    self.emit_child_stmt(stmt, s, fd)
             elif stmt.keyword == 'feature':
                 self.emit_feature(mod,stmt, fd)
             elif stmt.keyword == 'deviation':
@@ -460,6 +462,9 @@ class uml_emitter:
                 self.emit_must_leaf(parent, node, fd)
             elif node.keyword == 'notification':
                 self.emit_notif(parent, node, fd)
+                if cont:
+                    for children in node.substmts:
+                        self.emit_child_stmt(node, children, fd)
             elif node.keyword in ['action', ('tailf-common', 'action')]:
                 self.emit_action(parent, node, fd)
             elif node.keyword == ('tailf-common', 'callpoint'):
@@ -722,8 +727,8 @@ class uml_emitter:
         # notif as class stereotype, ugly, but easier to layout params
         fd.write('class \"%s\" as %s << (N,#00D1B2) notification>> \n' % (self.full_display_path(node), self.full_path(node)))
         fd.write('%s -- %s : notification \n' % (self.make_plantuml_keyword(self.full_path(parent)), self.full_path(node)))
-        for params in node.substmts:
-            self.emit_child_stmt(node, params, fd)
+        # for params in node.substmts:
+        #    self.emit_child_stmt(node, params, fd)
 
         # ALTERNATIVE 2
         # notif as oper, better, but hard to layout params


### PR DESCRIPTION
Notifications defined in interior data nodes (containers, lists) are not rendered in the UML diagram generated by the UML Plugin. 
This pull request fixes this shortcoming,

The following example illustrate what has been fixed.

The following YANG data model were used to test this fix:
<details>
<summary>test-notifications</summary>

```
module test-notifications {
  yang-version 1.1;
  namespace "http://www.example.com/ns/yang/test-notifications";
  prefix tst-nfc;
  revision 2023-07-21 {
    description
      "Initial revision.";
    reference
      "None.";
  }
  grouping notificatication-grouping {
    description
      "A grouping defining a notification.";
    notification grp-nfc {
      description
        "A notification in a list.";
      leaf binary-leaf {
        type binary;
        description
          "A leaf in a notification that is in a list.";
      }
    }
  }
  container container-a {
    description
      "A top-level container.";
    list list-a {
      key name;
      description
        "A list in a top-level container.";
      leaf name {
        type string;
        description
          "The name of the entry.";
      }
      notification list-a-nfc {
        description
          "A notification in a list.";
        leaf binary-leaf {
          type binary;
          description
            "A leaf in a notification that is in a list.";
        }
        container container-3 {
          description
            "A container in a notification that is in a list.";
          leaf another-leaf {
            type string;
            description
              "Just another leaf.";
          }
          leaf b-list-ref {
            type leafref {
              path 
                "/tst-nfc:container-b"
                + "/tst-nfc:list-b/tst-nfc:name";
            }
          }
        }
      }
    } 
  }
  container container-b {
    description
      "A another top-level container.";
    list list-b {
      key name;
      description
        "A list in a top-level container.";
      leaf name {
        type string;
        description
          "The name of the entry.";
      }
      uses notificatication-grouping;
    }
  }
  notification top-level-nfc {
    description
      "A top-level notification.";
    container container-4 {
      description
        "A container in a top-level notification.";
      leaf a-leaf {
        type uint32;
        description
          "Just a leaf.";
      }
      leaf list-b-ref {
        type leafref {
          path 
            "/tst-nfc:container-b"
            + "/tst-nfc:list-b/tst-nfc:name";
        }
      }
    }
    leaf just-a-leaf {
      type string;
      description
        "A leaf in a top-level notification.";
    }
  }
}
```
</details>

# Example
## Before the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/205dac8f-84c3-447a-b8f2-2500bc86a4c2)

## After the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/12acdf21-2907-4037-9312-ed71e397f79f)
