### PR TITLE
Replace sys.exit with return.

### DIFF
--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -195,7 +195,7 @@ def check_update(ctx, newmod):
             text = fd.read()
         except IOError as ex:
             sys.stderr.write("error %s: %s\n" % (oldfilename, ex))
-            sys.exit(1)
+            return
         if oldfilename in ctx.opts.old_deviation:
             oldctx.add_module(oldfilename, text)
         else:

--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -161,6 +161,9 @@ class CheckUpdatePlugin(plugin.PyangPlugin):
         error.add_error_code(
             'CHK_UNION_TYPES', 3,
             "the member types in the union have changed")
+        error.add_error_code(
+            'CHK_IO_ERROR', 1,
+            "error %s: %s")
 
     def post_validate_ctx(self, ctx, modules):
         if not ctx.opts.check_update_from:
@@ -194,7 +197,8 @@ def check_update(ctx, newmod):
             fd = io.open(oldfilename, "r", encoding="utf-8")
             text = fd.read()
         except IOError as ex:
-            sys.stderr.write("error %s: %s\n" % (oldfilename, ex))
+            pos = Position(oldfilename)
+            err_add(oldctx.errors, pos, "CHK_IO_ERROR", (oldfilename, ex))
             return
         if oldfilename in ctx.opts.old_deviation:
             oldctx.add_module(oldfilename, text)

--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -197,7 +197,7 @@ def check_update(ctx, newmod):
             fd = io.open(oldfilename, "r", encoding="utf-8")
             text = fd.read()
         except IOError as ex:
-            pos = Position(oldfilename)
+            pos = error.Position(oldfilename)
             err_add(oldctx.errors, pos, "CHK_IO_ERROR", (oldfilename, ex))
             return
         if oldfilename in ctx.opts.old_deviation:

--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -198,7 +198,7 @@ def check_update(ctx, newmod):
             text = fd.read()
         except IOError as ex:
             pos = error.Position(oldfilename)
-            err_add(oldctx.errors, pos, "CHK_IO_ERROR", (oldfilename, ex))
+            err_add(ctx.errors, pos, "CHK_IO_ERROR", (oldfilename, ex))
             return
         if oldfilename in ctx.opts.old_deviation:
             oldctx.add_module(oldfilename, text)


### PR DESCRIPTION
If other modules import this code, an exit in a library may have unintended consequences.  Like in other places, use return instead of exit.