### PR TITLE
UML Plugin: Fix direction of the generalization and realization versions of th uses relation

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -286,7 +286,7 @@ class uml_emitter:
         if ctx.opts.uml_uses != "":
             if ctx.opts.uml_uses in uses_strings:
                 if ctx.opts.uml_uses == 'generalization':
-                    self.uses_relation_symbol = "<|--"
+                    self.uses_relation_symbol = "--|>"
                 elif ctx.opts.uml_uses == 'aggregation':
                     self.uses_relation_symbol = "o--"
                 elif ctx.opts.uml_uses == 'association':
@@ -297,7 +297,7 @@ class uml_emitter:
                     self.uses_relation_symbol = "..>"
                     self.uses_relation_label = "<<uses>>"
                 elif ctx.opts.uml_uses == 'realization':
-                    self.uses_relation_symbol = "<|.."
+                    self.uses_relation_symbol = "..|>"
             else:
                 sys.stderr.write("\"%s\" no valid argument to --uml-uses=...,  valid arguments (one only): %s \n" %(ctx.opts.uml_uses, uses_strings))
 


### PR DESCRIPTION
When using the UML option --uml-uses=generalization or --uml-uses=realization added with PR #868, the generalization or realization relation is rendered the wrong way around. 

Assuming that a grouping is considered an abstract class (superclass), then the class which includes the uses statement can be considered the subclass of this abstract class (the grouping) and thus a generalization relation should define a path from the subclass to the superclass with the hollow triangle at the end of the path where it meets the more general superclass.

The following example illustrate what has been fixed.

<details>
<summary>The YANG data model used to test this fix</summary>

```
module test-uses-grouping {
  namespace "http://www.example.com/ns/yang/my-uses-module-1";
  prefix tst-uses-grp;

  revision 2024-01-31 {
    description
      "Initial revision.";
    reference
      "None.";
  }

  grouping grouping {
    description
      "A grouping.";
    leaf a-leaf {
      type string;
      description
        "A leaf.";
    }
  }

  container container {
    description
      "A container.";
    uses grouping;
  }
}
```
</details>

# Example
## Before the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/b4ee9f4b-e950-4a6d-8d68-73f31604afc3) ![image](https://github.com/mbj4668/pyang/assets/11681631/447001ac-ee54-4cf7-bed2-ec13182851a5)


## After the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/0f2f5965-d424-47a4-8322-6e1766b2e035) ![image](https://github.com/mbj4668/pyang/assets/11681631/5cd6753f-1567-4bab-bf6d-e4017101da2a)

