### PR TITLE
UML Plugin: Fix top-level uses statement being ignored

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -515,7 +515,7 @@ class uml_emitter:
                 for children in node.substmts:
                     self.emit_child_stmt(node, children, fd)
         elif node.keyword == 'uses':
-            if not self.ctx_filterfile and not self._ctx.opts.uml_inline and not self.ctx_classesonly:
+            if not self.ctx_filterfile and not self._ctx.opts.uml_inline:
                 fd.write('%s : %s {uses} \n' %(self.full_path(parent), node.arg))
             if not self._ctx.opts.uml_inline:
                 self.emit_uses(parent, node)

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -422,6 +422,9 @@ class uml_emitter:
         elif stmt.keyword == 'grouping' and not self._ctx.opts.uml_inline:
             self.emit_grouping(mod, stmt, fd, True)
 
+        elif stmt.keyword == 'uses':
+            self.emit_child_stmt(mod, stmt, fd)
+
         elif stmt.keyword == 'choice':
             if not self.ctx_filterfile:
                 fd.write('class \"%s\" as %s <<choice>> \n' % (self.full_display_path(stmt), self.full_path(stmt)))

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -515,7 +515,7 @@ class uml_emitter:
                 for children in node.substmts:
                     self.emit_child_stmt(node, children, fd)
         elif node.keyword == 'uses':
-            if not self.ctx_filterfile and not self._ctx.opts.uml_inline:
+            if not self.ctx_filterfile and not self._ctx.opts.uml_inline and not self.ctx_classesonly:
                 fd.write('%s : %s {uses} \n' %(self.full_path(parent), node.arg))
             if not self._ctx.opts.uml_inline:
                 self.emit_uses(parent, node)


### PR DESCRIPTION
When rendering YANG modules with a 'uses' statement at the module level, such as can be found the YANG module openconfig-telemetry@2018-11-21, the top-level uses statement is ignored. This pull request fixes this issue.

The following examples illustrate what has been fixed.

The following YANG data models were used to test this fix:

<details>
<summary>test-groupings</summary>

```
module test-groupings {
  namespace "http://www.adtran.com/ns/yang/test-groupings";
  prefix tst-grp;

  revision 2024-03-11 {
    description
      "Initial revision.";
    reference
      "None.";
  }

  grouping grouping-1 {
    description
      "A grouping with a top-level non-interior data node.";
    leaf a-top-level-leaf-in-a-grouping {
      type string;
      description
        "Bla bla bla.";
    }
  }

  grouping grouping-2 {
    description
      "A grouping with a top-level interior data node.";
    container a-top-level-container {
      leaf a-leaf-within-a-top-level-container-in-a-grouping {
        type string;
        description
          "Bla bla bla.";
      }
    }
  }
}
```
</details>

<details>
<summary>test-uses-top-level</summary>

```
module test-uses-top-level {
  namespace "http://www.adtran.com/ns/yang/test-uses-top-level";
  prefix tst-uses-top;

  import test-groupings {
    prefix tst-grp;
  }

  revision 2024-03-11 {
    description
      "Initial revision.";
    reference
      "None.";
  }

  uses tst-grp:grouping-1;
  uses tst-grp:grouping-2;

}
```
</details>

# Example 1: UML option --uml-inline-groupings not used
## Before the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/43e81a6d-77ee-445b-a3b1-59b946c9f459)

## After the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/85dc96c2-8af1-4994-94b1-3bb767a28a09)

# Example 2: UML option --uml-inline-groupings used
## Before the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/e9f38a36-66a4-4fa5-8f0c-b15470087292)

## After the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/6a4a9a6c-cfaf-476b-aef4-fedbf66be86f)




