### PR TITLE
UML Plugin: Fix uses attributes not hidden when using UML option --uml-classes-only

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -512,7 +512,7 @@ class uml_emitter:
                 for children in node.substmts:
                     self.emit_child_stmt(node, children, fd)
         elif node.keyword == 'uses':
-            if not self.ctx_filterfile and not self._ctx.opts.uml_inline:
+            if not self.ctx_filterfile and not self._ctx.opts.uml_inline and not self.ctx_classesonly:
                 fd.write('%s : %s {uses} \n' %(self.full_path(parent), node.arg))
             if not self._ctx.opts.uml_inline:
                 self.emit_uses(parent, node)


### PR DESCRIPTION
When rendering YANG modules with 'uses' statements using the UML option `--uml-classes-only`, the {uses} attributes of the class representing the YANG statement in which the 'uses' statement is used are not suppressed as would be expected. This pull request fixes this issue.

The following examples illustrate what has been fixed.

The following YANG data models were used to test this fix:

<details>
<summary>test-groupings</summary>

```
module test-groupings {
  namespace "http://www.adtran.com/ns/yang/test-groupings";
  prefix tst-grp;

  revision 2024-03-11 {
    description
      "Initial revision.";
    reference
      "None.";
  }

  grouping grouping-1 {
    description
      "A grouping with a top-level non-interior data node.";
    leaf a-top-level-leaf-in-a-grouping {
      type string;
      description
        "Bla bla bla.";
    }
  }

  grouping grouping-2 {
    description
      "A grouping with a top-level interior data node.";
    container a-top-level-container {
      leaf a-leaf-within-a-top-level-container-in-a-grouping {
        type string;
        description
          "Bla bla bla.";
      }
    }
  }
}
```
</details>

<details>
<summary>test-uses-interior</summary>

```
module test-uses-interior {
  namespace "http://www.adtran.com/ns/yang/test-uses-interior";
  prefix tst-uses-int;

  import test-groupings {
    prefix tst-grp;
  }

  revision 2024-03-11 {
    description
      "Initial revision.";
    reference
      "None.";
  }

  container top-level-container {
    description
      "A uses statement within a top-level interior node
       (container).";
    uses tst-grp:grouping-1;
    uses tst-grp:grouping-2;
  }
}
```
</details>

# Example
## --uml-classes-only not used
![image](https://github.com/mbj4668/pyang/assets/11681631/99cd094b-bad4-41aa-9f46-212e25adf902)

## --uml-classes-only used
### Before the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/f91bb3d4-285a-418d-aa7a-8d469e4387b4)

### After the fix:
![image](https://github.com/mbj4668/pyang/assets/11681631/360ef963-c665-430a-8932-f52a29786429)




