### PR TITLE
UML Plugin: Fix incorrect error message when using UML option --uml-no=identity

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -236,7 +236,7 @@ class uml_emitter:
         self.ctx_title = not "title" in no
         self.ctx_footer = not "footer" in no
 
-        nostrings = ("module", "leafref", "uses", "annotation", "identityref", "typedef", "import", "circles", "stereotypes", "prefix", "footer", "title")
+        nostrings = ("module", "uses", "leafref", "identity", "identityref", "typedef", "import", "annotation", "circles", "stereotypes", "prefix", "footer", "title")
         if ctx.opts.uml_no != "":
             for no_opt in no:
                 if no_opt not in nostrings:


### PR DESCRIPTION
When using the UML option --uml-no=identity as listed as available in the help for UML options, pyang issues the following error message, but correctly renders the UML without identities as expected.

`"identity" no valid argument to --uml-no=...,  valid arguments: ('module', 'leafref', 'uses', 'annotation', 'identityref', 'typedef', 'import', 'circles', 'stereotypes', 'prefix', 'footer', 'title') 
`

This error message is issued becaused the keyword "identity" is not included in the  tuple 'nostrings', against which the UML plugin checks the validity of the uml-no arguments. 

This fix adds the string "identity" to 'nostrings'. It also reorders the strings (has no effect) to align with the order listed in the help information for easier comparison.

This fix was verified using the module [bbf-hardware-types](https://github.com/BroadbandForum/yang/blob/master/standard/equipment/bbf-hardware-types.yang), which contains only feature and identity statements.