### PR TITLE
detect xslt_dir and schema_dir in yang2dsdl

### DIFF
--- a/bin/yang2dsdl
+++ b/bin/yang2dsdl
@@ -28,8 +28,17 @@ onlydata=0
 hello=0
 jing=0
 
-xslt_dir=${PYANG_XSLT_DIR:-/usr/local/share/yang/xslt}
-schema_dir=${PYANG_RNG_LIBDIR:-/usr/local/share/yang/schema}
+bin_dir=$(dirname $0)
+prefix=${bin_dir}/..
+
+if [ -d $prefix/.git ] && [ -f $prefix/setup.py ]; then
+	base_dir=$prefix
+else
+	base_dir=$prefix/share/yang
+fi
+
+xslt_dir=${PYANG_XSLT_DIR:-$base_dir/xslt}
+schema_dir=${PYANG_RNG_LIBDIR:-$base_dir/schema}
 
 usage() {
     cat <<EOF


### PR DESCRIPTION
When pyang is user-installed (i.e. into .local/), PYANG_XSLT_DIR and PYANG_RNG_LIBDIR would have to be specified.

With this, they are looked up relative to the yang2dsl script.

When running from a git checkout, the paths are different once again, also detected by looking for .git/ and setup.py.