### PR TITLE
JSONXSL Plugin: Fix type for uint64 and int64 type for jsonxsl conversion

### DIFF
--- a/pyang/plugins/jsonxsl.py
+++ b/pyang/plugins/jsonxsl.py
@@ -36,16 +36,16 @@ ss = ET.Element("stylesheet",
 """Root element of the output XSLT stylesheet."""
 
 type_class = dict((t,"unquoted") for t in
-                  ("boolean", "int8", "int16", "int32",
-                   "uint8", "uint16", "uint32"))
+                  ("boolean", "int8", "int16", "int32", "int64",
+                   "uint8", "uint16", "uint32", "uint64"))
 """Classification of types suited for JSON translation."""
 
 type_class.update((t,t) for t in
                   ("empty", "instance-identifier", "identityref", "string"))
 
 union_class = dict((t,"integer") for t in
-                   ("int8", "int16", "int32",
-                   "uint8", "uint16", "uint32"))
+                   ("int8", "int16", "int32", "int64",
+                   "uint8", "uint16", "uint32", "uint64"))
 """Classification of types needed for resolving union-typed values."""
 
 union_class.update({"boolean": "boolean"})


### PR DESCRIPTION
As part of ietf-yang-types.yang, there is a standard type of uint64 and int64 which should be defined as integer types. Currently these are not listed in the `type_class` or `union_class` definitions for the jsonxsl plugin.

See the rfc6021 definition for standard data types here:

https://datatracker.ietf.org/doc/html/rfc6021#section-3

When using the current definition, the datatype for a uint64/int64 type becomes `other` which results in the value being incorrectly quoted when fed through `xsltproc`.

This commit will add these data types in as unquoted / integer types similar to the other similar data types.