### PR TITLE
Replace deprecated pkg_resources with importlib for Python >=3.12

### DIFF
--- a/pyang/plugin.py
+++ b/pyang/plugin.py
@@ -2,7 +2,10 @@
 
 import os
 import sys
-import pkg_resources
+if sys.version_info >= (3, 12):
+    import importlib.resources as resources
+else:
+    import pkg_resources
 
 plugins = []
 """List of registered PyangPlugin instances"""
@@ -19,7 +22,11 @@ def init(plugindirs=None):
     dsdl.pyang_plugin_init()
 
     # initialize installed plugins
-    for ep in pkg_resources.iter_entry_points(group='pyang.plugin'):
+    if sys.version_info >= (3, 12):
+        eps = list(resources.entry_points(group='pyang.plugin'))
+    else:
+        eps = pkg_resources.iter_entry_points(group='pyang.plugin')
+    for ep in eps:
         plugin_init = ep.load()
         plugin_init()
 

--- a/pyang/plugin.py
+++ b/pyang/plugin.py
@@ -3,7 +3,7 @@
 import os
 import sys
 if sys.version_info >= (3, 12):
-    import importlib.resources as resources
+    import importlib.metadata as metadata
 else:
     import pkg_resources
 
@@ -23,7 +23,7 @@ def init(plugindirs=None):
 
     # initialize installed plugins
     if sys.version_info >= (3, 12):
-        eps = list(resources.entry_points(group='pyang.plugin'))
+        eps = list(metadata.entry_points(group='pyang.plugin'))
     else:
         eps = pkg_resources.iter_entry_points(group='pyang.plugin')
     for ep in eps:


### PR DESCRIPTION
Depending on Python version use pkg_resources (old behavior) or use importlib to check for plugins.

Closes #911 