### PR TITLE
Fix for statements like 'deviate add' in deviation yang modules causing prefix resolution failure

### DIFF
--- a/pyang/context.py
+++ b/pyang/context.py
@@ -343,6 +343,13 @@ class Context(object):
             m = self.modules[k]
             if m is not None:
                 modules.append(m)
+        # First, ensure all deviation modules are fully validated (including
+        # their imports) before validating main modules. This fixes issues where
+        # deviation statements use prefixed values (e.g., identityref in default
+        # statements) that require imports to be resolved.
+        for dev_mod in self.deviation_modules:
+            if dev_mod is not None and not dev_mod.i_is_validated:
+                statements.validate_module(self, dev_mod)
         for m in modules:
             # may add new modules by import
             statements.validate_module(self, m)

--- a/pyang/statements.py
+++ b/pyang/statements.py
@@ -1020,15 +1020,19 @@ def v_type_leaf(ctx, stmt):
     default = stmt.search_one('default')
     type_ = stmt.search_one('type')
     if default is not None and type_.i_type_spec is not None :
+        # Use the default statement's module if it's set (e.g., from deviate add),
+        # otherwise use the leaf's module. This ensures prefix resolution works
+        # correctly for default values added via deviation statements.
+        default_module = getattr(default, 'i_module', None) or stmt.i_module
         defval = type_.i_type_spec.str_to_val(ctx.errors,
                                               default.pos,
                                               default.arg,
-                                              stmt.i_module)
+                                              default_module)
         stmt.i_default = defval
         stmt.i_default_str = default.arg
         if defval is not None:
             type_.i_type_spec.validate(ctx.errors, default.pos,
-                                       defval, stmt.i_module,
+                                       defval, default_module,
                                        ' for the default value')
     elif (default is None and
           type_.i_typedef is not None and
@@ -2319,6 +2323,10 @@ def v_reference_deviate(ctx, stmt):
                     err_add(ctx.errors, c.pos, 'BAD_DEVIATE_TYPE',
                             c.keyword)
                 else:
+                    # Ensure i_module is set so prefix resolution works correctly
+                    # when validating default values with prefixed names
+                    if not hasattr(c, 'i_module') or c.i_module is None:
+                        c.i_module = stmt.i_module
                     t.substmts.append(c)
             else:
                 # multi-valued keyword; just add the statement if it is valid
@@ -2335,6 +2343,9 @@ def v_reference_deviate(ctx, stmt):
                         else:
                             # unknown module, let's assume the extension can
                             # be deviated
+                            # Ensure i_module is set so prefix resolution works correctly
+                            if not hasattr(c, 'i_module') or c.i_module is None:
+                                c.i_module = stmt.i_module
                             t.substmts.append(c)
                     else:
                         err_add(ctx.errors, c.pos, 'BAD_DEVIATE_TYPE',
@@ -2344,6 +2355,10 @@ def v_reference_deviate(ctx, stmt):
                             c.keyword)
 
                 else:
+                    # Ensure i_module is set so prefix resolution works correctly
+                    # when validating default values with prefixed names
+                    if not hasattr(c, 'i_module') or c.i_module is None:
+                        c.i_module = stmt.i_module
                     t.substmts.append(c)
     elif stmt.arg == 'replace':
         for c in stmt.substmts:


### PR DESCRIPTION
When pyang processes deviation modules with --deviation-module, statements added via deviate add (like default) don't have their i_module set correctly. When validating default values with prefixed names (e.g., ianaift:ethernetCsmacd), pyang uses the target node's module context instead of the deviation module's context, causing prefix resolution to fail.

Fix:
  * Set i_module on statements added via deviate add
  * Use the default statement's module context when validating default values
  * Ensure deviation modules are validated before main modules