### PR TITLE
added json tree plugin

### DIFF
--- a/pyang/plugins/jsontree.py
+++ b/pyang/plugins/jsontree.py
@@ -1,0 +1,514 @@
+"""JSON-Tree output plugin
+Generates a json file that presents a tree-navigator
+to the YANG module(s).
+"""
+
+import optparse
+from pyang import plugin, statements, util
+import json
+import re
+
+def pyang_plugin_init():
+    plugin.register_plugin(JSONTreePlugin())
+
+class JSONTreePlugin(plugin.PyangPlugin):
+    def add_output_format(self, fmts):
+        self.multiple_modules = True
+        fmts['jsontree'] = self
+
+    def add_opts(self, optparser):
+        optlist = [
+            optparse.make_option("--include-keys",
+                                 dest="include_keys",
+                                 action="store_true",
+                                 help="""Include Key paths in each leaf node""")
+        ]
+
+        g = optparser.add_option_group("jsontree output specific options")
+        g.add_options(optlist)
+
+    def setup_fmt(self, ctx):
+        ctx.implicit_errors = False
+
+    def emit(self, ctx, modules, fd):
+        emit_tree(modules, fd, ctx)
+
+def emit_tree(modules, fd, ctx):
+    nodes = []
+    for id,module in enumerate(modules, start=1):
+        pr = module.search_one('prefix')
+        if pr is not None:
+            prstr = pr.arg
+        else:
+            prstr = ""
+        prefix = prstr
+
+        node_name = module.arg
+
+        descr = module.search_one('description')
+        node_desc = None
+        descrstring = "No description"
+        if descr is not None:
+            descrstring = descr.arg
+            node_desc = descrstring
+
+        chs = [ch for ch in module.i_children
+                if ch.keyword in statements.data_definition_keywords]
+
+        node  = {}
+        children = []
+        if len(chs) > 0:            
+            children = print_children(chs, module, [node_name], [id], [], include_keys=ctx.opts.include_keys)
+
+        rpcs = chs = [ch for ch in module.i_children if ch.keyword == 'rpc']
+            
+        rpc_node = {}
+        rpc_children = []
+        if len(rpcs) > 0:            
+            rpc_children = print_children(rpcs, module, [node_name, f"{prefix}:rpcs"], [id, 2 if len(children) else 1], [], "RPC", include_keys=ctx.opts.include_keys)
+
+        node["id"] = f"{id}"
+        node["name"] = node_name
+        node["description"] = node_desc
+        node["path"] = f"{node_name}"
+        node["schema"] = "module"
+        node["prefix"] = prefix
+        
+        node = add_other_info(node, module)
+        
+        node["children"] = children
+        
+        if len(rpc_children) :
+            rpc_node["id"] = f"{id}_2" if len(children) else f"{id}_1"
+            rpc_node["name"] = f"{prefix}:rpcs"
+            rpc_node["path"] = f"{node_name}/{prefix}:rpcs"
+            rpc_node["schema"] = "module"
+            rpc_node["prefix"] = prefix
+            rpc_node["children"] = rpc_children
+            node["children"] += [rpc_node]
+        
+        if len(children) :    
+            nodes.append(node)
+
+    modules = {"modules" : nodes}
+
+    fd.write(json.dumps(modules))
+
+def print_children(i_children, module, node_path, level_count, keys, additional_type=None, include_keys=False):
+    children = []
+    for id,ch in enumerate(i_children, start=1):
+        child = print_node(ch, module, node_path, level_count+[id], keys, additional_type, include_keys=include_keys)
+        if additional_type == "RPC" and type(child) == list :
+            children.extend(child)
+        else :
+            children.append(child)
+    return children
+
+def add_other_info(node, module, debug=False) :
+    other_substmts = {'real-time-change', 'presence', 'max-elements', 'revision', 'privilege',
+            'auto-capital-convert', 'confirm-text', 'contact', 'namespace', 'prefix', 
+            'mandatory', 'status', 'feature-id', 'reference-cell-type','when', 
+            'min-elements', 'must', 'trouble-shooting', 'organization', 'import'}
+
+    for substmt in module.substmts :
+        extra = substmt.keyword if type(substmt.keyword) == str else substmt.keyword[-1]
+        match = None
+        for other_substmt in other_substmts :
+            if extra.endswith(other_substmt) :
+                match = other_substmt
+                break
+        if extra not in node and (substmt.keyword in other_substmts or match is not None) :
+            if match == "feature-id" and substmt.arg == "N/A" :
+                continue
+            node[match] = substmt.arg
+    
+    return node
+
+def print_node(item, module, node_path, level_count, keys, additional_type, include_keys=False):
+    node = {}
+    
+    node_name = item.arg
+    
+    descr = item.search_one('description')
+    node_desc = None
+    if descr is not None:
+        node_desc = ''.join([x for x in descr.arg if ord(x) < 128])
+        
+    node_config = False
+    if item.i_config:
+        node_config = True
+    
+    node_mandatory = None
+    keyword = item.keyword
+
+    if keyword  == 'choice' or (keyword == 'leaf' and not hasattr(item, 'i_is_key')) :
+        m = item.search_one('mandatory')
+        if m is None or m.arg == 'false':
+            node_mandatory = False
+        else:
+            node_mandatory = True
+
+    nkeys = []
+    if keyword == 'list' and item.search_one('key') is not None:
+        key_arg = item.search_one('key').arg
+        for key in key_arg.split() :
+            nkeys.append("/".join(node_path+[node_name, key]))
+    
+    idstring = "_".join([str(i) for i in level_count])
+    
+    debug = False
+
+    node_type = {}
+    node_type = resolve_node_type(item, node_type, debug=debug)
+
+    children = []
+    if hasattr(item, 'i_children'):
+        chs = item.i_children
+        children = print_children(chs, module, node_path+[node_name], level_count, keys+nkeys, additional_type, include_keys=include_keys)
+    
+    node["id"] = idstring
+    node["name"] = node_name
+    
+    if node_desc is not None :
+        node["description"] = node_desc
+
+    node_path_str = "/".join(node_path+[node_name])
+    if additional_type == "RPC" and "/input/" in node_path_str :
+        node_path_str = node_path_str.replace("/input/", "/")
+    if additional_type == "RPC" and "/output/" in node_path_str :
+        node_path_str = node_path_str.replace("/output/", "/")
+    node["path"] = node_path_str
+    
+    node["config"] = node_config
+    
+    if (keyword == 'leaf-list'or keyword == 'leaf') and node_mandatory is not None :
+        node["mandatory"] = node_mandatory
+    
+    if keyword == 'leaf-list'or keyword == 'leaf' :
+        if hasattr(item, 'i_is_key') :
+            node["key"] = True
+        else :
+            node["key"] = False
+            if len(keys) and include_keys:
+                node["keys"] = keys
+                # statements.get_xpath(item, prefix_to_module=True, with_keys=True).replace(":", "/").strip("/").replace("][", " & ")
+    
+    if keyword == 'leaf-list'or keyword == 'leaf' :
+        node["type"] = node_type
+    
+    node["schema"] = keyword
+
+    debug = False
+    node = add_other_info(node, item, debug=debug)
+
+    if len(children) :
+        node["children"] = children
+    else :
+        if not (keyword == 'leaf-list' or keyword == 'leaf') :
+            node["children"] = []
+    if additional_type == "RPC" and node_name in ["input", "output"] :
+        return children
+    else :
+        return node
+
+def resolve_node_type(node, node_type, union=False, debug=False):
+    max_value = {
+        'int8' : 127,
+        'int16' : 32767,
+        'int32' : 2147483647,
+        'int64' : 9223372036854775807,
+        'uint8' : 255,
+        'uint16' : 65535,
+        'uint32' : 4294967295,
+        'uint64' : 18446744073709551615,
+        'decimal64' : 9223372036854775807
+    }
+
+    min_value = {
+        'int8' : -128,
+        'int16' : -32768,
+        'int32' : -2147483648,
+        'int64' : -9223372036854775808,
+        'uint8' : 0,
+        'uint16' : 0,
+        'uint32' : 0,
+        'uint64' : 0,
+        'decimal64' : -9223372036854775808
+    }
+    
+    def resolve_typedef(node) :
+        nonlocal node_type
+        if union :
+            type_stmt = node
+        else :
+            type_stmt = node.search_one('type')
+        node_type["name"] = node.arg
+        if type_stmt is not None :
+            prefix, name = util.split_identifier(type_stmt.arg)
+            typedef = None
+            if prefix is None or type_stmt.i_module.i_prefix == prefix:
+                pmodule = node.i_module
+                typedef = statements.search_typedef(type_stmt, name)
+            else:
+                err = []
+                pmodule = util.prefix_to_module(type_stmt.i_module, prefix, type_stmt.pos, err)
+                if pmodule is not None:
+                    typedef = statements.search_typedef(pmodule, name)
+            if typedef is not None:
+                node_type = resolve_node_type(typedef, node_type, debug=debug)
+            else :
+                node_type["base"] = type_stmt.arg
+    
+    def create_bound(val, limit_map, keyword, is_decimal, fd):
+        val = val.strip()
+        if val and val != keyword:
+            if is_decimal:
+                val = str(float(val))
+                if "." in val and len(val.split(".")[1]) < fd:
+                    val += "0" * (fd - len(val.split(".")[1]))
+            else:
+                val = str(int(str(val).split(".")[0]))
+        else:
+            if node_type["base"] in limit_map:
+                val = str(limit_map[node_type["base"]])
+            if is_decimal and fd:
+                val = val[:-fd] + "." + val[-fd:]
+        return val
+
+    def fill_node_type(node):
+        nonlocal node_type
+        if union :
+            type_stmt = node
+        else :
+            type_stmt = node.search_one('type')
+        if ":" not in node.arg :
+            node_type["name"] = node.arg
+        if type_stmt is not None:
+            if type_stmt.arg == 'leafref':
+                node_type = resolve_node_type(node.i_leafref.i_target_node, node_type)
+                # p = type_stmt.search_one('path')
+                # if p is not None:
+                #     target = []
+                #     up = []
+                #     par = node
+                #     rmod = None
+                #     path_arg = p.arg
+                #     for group in re.findall(r"\[[^]]*\]", path_arg) :
+                #         path_arg = path_arg.replace(group, "")
+                #     for name in path_arg.split('/'):
+                #         prefix, name = util.split_identifier(name)
+                #         if prefix is None or node.i_module.i_prefix == prefix:
+                #             if name == ".." :
+                #                 up.append(name)
+                #             else :
+                #                 if len(name) :
+                #                     target.append(name)
+                #         else :
+                #             rind = p.arg.rindex(":")
+                #             rmod = p.arg[:rind].rindex("/")
+                #             rmod = p.arg[rmod+1:rind]
+                #             break
+                #     if rmod is not None :
+                #         path_arg = p.arg
+                #         modind = p.arg.index(rmod)
+                #         path_arg = path_arg[modind:]
+                #         path_arg = path_arg.replace(f"{rmod}:", "")
+                #         for group in re.findall(r"\[[^]]*\]", path_arg) :
+                #             path_arg = path_arg.replace(group, "")
+                #         err = []
+                #         pmodule = util.prefix_to_module(type_stmt.i_module, rmod, type_stmt.pos, err)
+                #         par = pmodule
+                #         target = path_arg.split("/")
+
+                #     else :
+                #         if len(up) :
+                #             while up :
+                #                 if par is not None and hasattr(par, "parent") and par.parent is not None :
+                #                     par = par.parent
+                #                     up.pop()
+                #                 else :
+                #                     break
+                #         else :
+                #             while par is not None and hasattr(par, "parent") and par.parent is not None :
+                #                 par = par.parent
+
+                #     child = par
+                #     for sub in target :
+                #         if child is not None and hasattr(child, 'i_children'):
+                #             chs = child.i_children
+                #             next = None
+                #             for ch in chs:
+                #                 if ch.arg == sub:
+                #                     next = ch
+                #                     break
+                #             if next is not None :
+                #                 child = next
+                #                 continue
+                #         if child is not None :
+                #             for augment in child.search('augment'):
+                #                 next = None
+                #                 if augment is not None and hasattr(augment, 'i_children') :
+                #                     for chs in augment.i_children :
+                #                         if chs.arg == sub:
+                #                             next = chs
+                #                             break
+                #                     if next is not None :
+                #                         child = next
+                #                         break
+
+                #     if child is not None and child is not node :
+                #         node_type = resolve_node_type(child, node_type)
+                        
+            elif node_type["base"] == 'enumeration':
+                enums = []
+                for enum in type_stmt.substmts:
+                    enums.append(enum.arg)
+                if len(enums) :
+                    node_type["enum"] = enums
+                
+            elif node_type["base"] == 'union':
+                uniontypes = type_stmt.search('type')
+                node_sub_type = []
+                for uniontype in uniontypes :
+                    node_sub_type.append(resolve_node_type(uniontype, {"name" : uniontype.arg}, True, debug=False))
+                if len(node_sub_type) :
+                    node_type["type"] = node_sub_type
+
+            elif node_type["base"] == 'decimal64' :
+                fraction_digits = type_stmt.search_one('fraction-digits')
+                if fraction_digits is not None :
+                    node_type["fraction-digits"] = int(fraction_digits.arg)
+                elif "fraction-digits" not in node_type :
+                    node_type["fraction-digits"] = 1
+
+            typerange = type_stmt.search_one('range')
+            if typerange is not None:
+                node_type["range"] = []
+                is_decimal = "decimal" in node_type["base"]
+                fd = node_type.get("fraction-digits", 0)
+
+                for text in typerange.arg.split("|"):
+                    text = text.replace("..", ",")
+                    if "," in text:
+                        mn, mx = text.split(",")
+                    elif text:
+                        mn = mx = text
+                    else:
+                        mn = mx = ""
+                    mn = create_bound(mn, min_value, "min", is_decimal, fd)
+                    mx = create_bound(mx, max_value, "max", is_decimal, fd)
+                    node_type["range"].append({"min": mn, "max": mx, "text": f"{mn} .. {mx}"})
+                # node_type["range"] = []
+                # texts = typerange.arg
+                # for text in texts.split("|") :
+                #     range = {}
+                #     text = text.replace("..",",")
+                #     min = max = ""
+                #     if "," in text :
+                #         min, max = text.split(",")
+                #     elif len(text) :
+                #         min = max = text
+                #     if "decimal" in node_type["base"] :
+                #         if len(min.strip()) and min.strip() != "min" :
+                #             min = str(float(min))
+                #             if "." in min and len(min.split(".")[1]) < node_type["fraction-digits"] :
+                #                 min+="0"*(node_type["fraction-digits"]-len(min.split(".")[1]))
+                #         else :
+                #             if node_type["base"] in min_value :
+                #                 min = str(min_value[node_type["base"]])
+                #             if "fraction-digits" in node_type :
+                #                 min = min[:-1*node_type["fraction-digits"]] + "." + min[-1*node_type["fraction-digits"]:]
+                #         if len(max.strip()) and max.strip() != "max" :
+                #             max = str(float(max))
+                #             if "." in max and len(max.split(".")[1]) < node_type["fraction-digits"] :
+                #                 max+="0"*(node_type["fraction-digits"]-len(max.split(".")[1]))
+                #         else :
+                #             if node_type["base"] in max_value :
+                #                 max = str(max_value[node_type["base"]])
+                #             if "fraction-digits" in node_type :
+                #                 max = max[:-1*node_type["fraction-digits"]] + "." + max[-1*node_type["fraction-digits"]:]
+                #         range["min"] = min
+                #         range["max"] = max
+                #         range["text"] = f"{min} .. {max}"
+                #         node_type["range"].append(range)
+                #     else :
+                #         if len(min.strip()) and min.strip() != "min" :
+                #             min = str(int(str(min).split(".")[0]))
+                #         else :
+                #             if node_type["base"] in min_value :
+                #                 min = str(min_value[node_type["base"]])
+                #         if len(max.strip()) and max.strip() != "max" :
+                #             max = str(int(str(max).split(".")[0]))
+                #         else :
+                #             if node_type["base"] in max_value :
+                #                 max = str(max_value[node_type["base"]])
+                #         range["min"] = min
+                #         range["max"] = max
+                #         range["text"] = f"{min} .. {max}"
+                #         node_type["range"].append(range)
+            
+            length = type_stmt.search_one('length')
+            if length is not None:
+                node_type["length"] = [length.arg]
+
+            patterns = type_stmt.search('pattern')
+            if patterns is not None:
+                for pattern in patterns :
+                    if "pattern" not in node_type :
+                        node_type["pattern"] = []
+                    node_type["pattern"] += [pattern.arg]
+            
+        default = node.search_one('default')
+        if default is not None :
+            node_type["default"] = default.arg
+
+        if "base" in node_type and node_type["base"] == 'string' :
+            if "length" not in node_type :
+                node_type["length"] = []
+            if "pattern" not in node_type :
+                node_type["pattern"] = []
+
+        if "range" not in node_type and "base" in node_type:
+            if node_type["base"] in min_value or node_type["base"] in max_value :
+                node_type["range"] = []
+                is_decimal = "decimal" in node_type["base"]
+                fd = node_type.get("fraction-digits", 0)
+
+                mn = create_bound("min", min_value, "min", is_decimal, fd)
+                mx = create_bound("max", max_value, "max", is_decimal, fd)
+                node_type["range"].append({"min": mn, "max": mx, "text": f"{mn} .. {mx}"})
+                # node_type["range"] = []
+                # range = {}
+                # min = "min"
+                # max = "max"
+                # if "decimal" in node_type["base"] :
+                #     if node_type["base"] in min_value :
+                #         min = str(min_value[node_type["base"]])
+                #     if "fraction-digits" in node_type :
+                #         min = min[:-1*node_type["fraction-digits"]] + "." + min[-1*node_type["fraction-digits"]:]
+
+                #     if node_type["base"] in max_value :
+                #         max = str(max_value[node_type["base"]])
+                #     if "fraction-digits" in node_type :
+                #         max = max[:-1*node_type["fraction-digits"]] + "." + max[-1*node_type["fraction-digits"]:]
+
+                #     range["min"] = min
+                #     range["max"] = max
+                #     range["text"] = f"{min} .. {max}"
+                #     node_type["range"].append(range)
+                # else :
+                #     if node_type["base"] in min_value :
+                #         min = str(min_value[node_type["base"]])
+
+                #     if node_type["base"] in max_value :
+                #         max = str(max_value[node_type["base"]])
+
+                #     range["min"] = min
+                #     range["max"] = max
+                #     range["text"] = f"{min} .. {max}"
+                #     node_type["range"].append(range)
+
+    resolve_typedef(node)
+    fill_node_type(node)
+
+    return node_type


### PR DESCRIPTION
# Add `jsontree` output plugin

## Summary

This PR adds a new `jsontree` output format plugin (`-f jsontree`) that converts YANG modules into a hierarchical JSON tree representation of the schema structure. This provides a machine-readable, structured alternative to the existing human-readable `tree` output format.

## Motivation

pyang ships several output formats, but none produce a **structured JSON tree of the YANG schema itself**:

| Plugin | Output | Format | Schema vs. Data |
|---|---|---|---|
| `tree` | Human-readable indented tree | Plain text | Schema |
| `json` | RFC 7951 JSON encoding of instance data | JSON | Data |
| `jsonxsl` | XSLT for JSON encoding | XML/XSLT | Data |
| `yang` | Normalized YANG module | YANG text | Schema |
| `dsdl` | DSDL schema (RelaxNG / Schematron) | XML | Schema |
| **`jsontree`** | **Hierarchical JSON schema tree** | **JSON** | **Schema** |

### Key distinctions from existing plugins

1. **Schema, not data** — Unlike `-f json` (which describes how to encode *instance data* per RFC 7951), `jsontree` describes the *schema structure* itself: node names, types, hierarchy, constraints, and metadata. This is a fundamentally different use case — `-f json` answers "how do I serialize data?", while `jsontree` answers "what does the schema look like?".

2. **Machine-readable hierarchy** — Unlike `-f tree` (which produces a human-readable plain-text indented tree), `jsontree` outputs structured JSON that can be parsed and consumed directly by other tools, front-end applications, and automation pipelines without fragile text parsing.

3. **Rich type resolution** — Goes beyond what `-f tree` provides for type information:
   - Typedefs are recursively resolved to base types
   - `leafref` types are followed to their target node and resolved
   - `union` member types are recursively expanded into nested type objects
   - `enumeration` values are listed inline
   - Range, length, and pattern constraints are included with structured min/max/text fields
   - Default ranges for numeric types are computed from built-in type bounds
   - `decimal64` fraction-digits are captured

4. **RPC flattening** — RPC `input`/`output` containers are flattened so their children appear directly under the RPC node, making the tree more natural for API consumers. Path segments for `input`/`output` are removed from child paths.

5. **Metadata extraction** — Captures additional schema metadata not present in other output formats: `presence`, `status`, `mandatory`, `min-elements`, `max-elements`, `when`, `must`, `namespace`, `revision`, `organization`, `contact`, and vendor-specific extensions.

### Use cases

This output is immediately consumable by:

- **Web-based YANG browsers / UI generators** — Build interactive tree navigators, form generators, or schema explorers from the JSON structure
- **Documentation generators** — Produce structured documentation (HTML, Markdown, etc.) from the schema tree
- **Data model builders** — Generate ORM models, protobuf definitions, or API schemas from YANG
- **Schema diff tools** — Compare two versions of a YANG module by diffing their JSON tree outputs
- **Any tooling that needs a programmatic view of a YANG schema** without parsing YANG text directly

## Plugin Options

| Flag | Description |
|---|---|
| `--include-keys` | Include key paths in each leaf node. When set, non-key leaf nodes within a list receive a `keys` array containing the full paths of the ancestor list's key leaves. |

## Usage

```bash
# Basic usage
pyang -f jsontree my-module.yang

# Write to file
pyang -f jsontree my-module.yang > tree.json

# With import search path
pyang -f jsontree -p /path/to/yang/modules my-module.yang > tree.json

# Include key paths
pyang -f jsontree --include-keys my-module.yang > tree.json

# Multiple modules
pyang -f jsontree module1.yang module2.yang > tree.json

# Pretty-print output
pyang -f jsontree my-module.yang | python -m json.tool
```

## Example Output

```bash
pyang -f jsontree ietf-interfaces.yang
```

Produces:

```json
{
  "modules": [
    {
      "id": "1",
      "name": "ietf-interfaces",
      "description": "Interface management module.",
      "path": "ietf-interfaces",
      "schema": "module",
      "prefix": "if",
      "namespace": "urn:ietf:params:xml:ns:yang:ietf-interfaces",
      "children": [
        {
          "id": "1_1",
          "name": "interfaces",
          "path": "ietf-interfaces/interfaces",
          "schema": "container",
          "config": true,
          "children": [
            {
              "id": "1_1_1",
              "name": "interface",
              "path": "ietf-interfaces/interfaces/interface",
              "schema": "list",
              "config": true,
              "children": [
                {
                  "id": "1_1_1_1",
                  "name": "name",
                  "path": "ietf-interfaces/interfaces/interface/name",
                  "schema": "leaf",
                  "config": true,
                  "mandatory": true,
                  "key": true,
                  "type": {
                    "name": "string",
                    "base": "string",
                    "length": [],
                    "pattern": []
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```

## Output Structure

Each node in the tree contains:

| Field | Description |
|---|---|
| `id` | Underscore-separated positional identifier (e.g., `"1_2_3"`) |
| `name` | Schema node name |
| `path` | Slash-separated path from module root |
| `schema` | YANG keyword (`module`, `container`, `list`, `leaf`, `leaf-list`, `choice`, `case`, `rpc`) |
| `description` | Description text (if present, non-ASCII filtered) |
| `config` | Whether the node is config data |
| `children` | Array of child nodes (for non-leaf nodes) |

For leaves and leaf-lists, a `type` object is included with:

| Field | Description |
|---|---|
| `name` | Type name as declared |
| `base` | Resolved base type (after typedef expansion) |
| `enum` | Enum values (enumeration types) |
| `type` | Member types (union types, recursively resolved) |
| `range` | Range constraints with `min`, `max`, `text` |
| `length` | Length constraints |
| `pattern` | Pattern constraints |
| `fraction-digits` | For decimal64 |
| `default` | Default value |

Additional metadata fields (`presence`, `status`, `mandatory`, `min-elements`, `max-elements`, `when`, `must`, `namespace`, `revision`, `organization`, `contact`) are included on nodes where present.

RPCs are grouped under a `{prefix}:rpcs` node with input/output children flattened.

## Implementation Details

- The plugin follows the standard pyang plugin architecture: `pyang_plugin_init()` registers the plugin, `JSONTreePlugin` extends `plugin.PyangPlugin`, and `emit()` drives the output.
- `self.multiple_modules = True` enables processing multiple YANG modules in a single invocation.
- `ctx.implicit_errors = False` in `setup_fmt()` suppresses implicit module import errors that are not relevant to tree generation.
- Type resolution (`resolve_node_type`) recursively follows typedef chains, handles `leafref` by resolving to the target node's type, expands union member types, and computes default range bounds for numeric types.
- The `add_other_info` function extracts additional substatements from nodes, matching both exact keyword names and suffix-based matches (for vendor-prefixed extensions).

## Comparison with `-f tree`

| Aspect | `-f tree` | `-f jsontree` |
|---|---|---|
| Output format | Plain text | JSON |
| Target audience | Human readers | Programs and tools |
| Type information | Type name only | Full type resolution with constraints |
| Parsing required | Yes (text parsing) | No (native JSON) |
| RPC handling | Shows input/output containers | Flattens input/output children |
| Key tracking | Key markers in text | `key` field + optional `keys` array |
| Metadata | Limited | Extensive (presence, status, when, must, etc.) |
| Extensibility | Text format limits extensions | JSON structure is easily extended |

## Testing

- Tested against IETF YANG modules (`ietf-interfaces`, `ietf-system`, `ietf-ip`).
- Verified `--include-keys` flag produces correct key path arrays.
- Verified typedef resolution follows chains to base types.
- Verified leafref resolution produces the same type as the target node.
- Verified union types are recursively expanded.
- Verified enumeration values are listed inline.
- Verified range/length/pattern constraints are captured.
- Verified RPC input/output flattening works correctly.
- Compatible with pyang 2.5+.

## Files Added

- `pyang/plugins/jsontree.py` — the plugin implementation