### PR TITLE
check_update: handle unbounded/absent min/max-elements per RFC 7950

### DIFF
--- a/pyang/plugins/check_update.py
+++ b/pyang/plugins/check_update.py
@@ -583,22 +583,37 @@ def chk_mandatory(old, new, ctx):
             err_def_changed(oldmandatory, newmandatory, ctx)
 
 def chk_min_max(old, new, ctx):
+    # RFC 7950: 'min-elements' defaults to 0 and 'max-elements' defaults to
+    # 'unbounded', so an absent statement is equivalent to that default.  Fold
+    # the defaults into the comparison so that e.g. an added 'max-elements
+    # unbounded' (which equals the default) is not flagged as a restriction.
     oldmin = old.search_one('min-elements')
     newmin = new.search_one('min-elements')
     if newmin is None:
         pass
     elif oldmin is None:
-        err_def_added(newmin, ctx)
-    elif int(newmin.arg) > int(oldmin.arg):
+        if _min_elements_val(newmin.arg) > 0:
+            err_def_added(newmin, ctx)
+    elif _min_elements_val(newmin.arg) > _min_elements_val(oldmin.arg):
         err_def_changed(oldmin, newmin, ctx)
     oldmax = old.search_one('max-elements')
     newmax = new.search_one('max-elements')
     if newmax is None:
         pass
     elif oldmax is None:
-        err_def_added(newmax, ctx)
-    elif int(newmax.arg) < int(oldmax.arg):
+        if _max_elements_val(newmax.arg) < float('inf'):
+            err_def_added(newmax, ctx)
+    elif _max_elements_val(newmax.arg) < _max_elements_val(oldmax.arg):
         err_def_changed(oldmax, newmax, ctx)
+
+def _min_elements_val(arg):
+    # default for min-elements is 0 (RFC 7950 7.7.5)
+    return int(arg)
+
+def _max_elements_val(arg):
+    # 'unbounded' is a valid value for max-elements (RFC 7950 7.7.4) and
+    # represents no upper bound, i.e. positive infinity.
+    return float('inf') if arg == 'unbounded' else int(arg)
 
 def chk_presence(old, new, ctx):
     oldpresence = old.search_one('presence')

--- a/test/test_update/Makefile
+++ b/test/test_update/Makefile
@@ -1,6 +1,6 @@
 PYANG := $(PYANG) --print-error-code --check-update-from
 
-MODULES = a c f h i j k
+MODULES = a c f h i j k l
 DEVIATION_MODULES = d e
 
 test:

--- a/test/test_update/expect/l.out
+++ b/test/test_update/expect/l.out
@@ -1,0 +1,2 @@
+l@2014-04-01.yang:19: error: CHK_DEF_CHANGED
+l@2014-04-01.yang:24: error: CHK_DEF_ADDED

--- a/test/test_update/l.yang
+++ b/test/test_update/l.yang
@@ -1,0 +1,35 @@
+module l {
+  namespace urn:l;
+  prefix l;
+
+  revision 2014-03-01;
+
+  list a {
+    key id;
+    max-elements unbounded;
+    leaf id { type uint32; }
+  }
+  list b {
+    key id;
+    max-elements 5;
+    leaf id { type uint32; }
+  }
+  list c {
+    key id;
+    max-elements unbounded;
+    leaf id { type uint32; }
+  }
+  list d {
+    key id;
+    leaf id { type uint32; }
+  }
+  list e {
+    key id;
+    max-elements 5;
+    leaf id { type uint32; }
+  }
+  list f {
+    key id;
+    leaf id { type uint32; }
+  }
+}

--- a/test/test_update/l@2014-04-01.yang
+++ b/test/test_update/l@2014-04-01.yang
@@ -1,0 +1,36 @@
+module l {
+  namespace urn:l;
+  prefix l;
+
+  revision 2014-04-01;
+
+  list a {
+    key id;
+    max-elements unbounded;
+    leaf id { type uint32; }
+  }
+  list b {
+    key id;
+    max-elements unbounded;
+    leaf id { type uint32; }
+  }
+  list c {
+    key id;
+    max-elements 5;
+    leaf id { type uint32; }
+  }
+  list d {
+    key id;
+    max-elements 5;
+    leaf id { type uint32; }
+  }
+  list e {
+    key id;
+    leaf id { type uint32; }
+  }
+  list f {
+    key id;
+    max-elements unbounded;
+    leaf id { type uint32; }
+  }
+}


### PR DESCRIPTION
  Fixes #953
  `chk_min_max` in `check_update.py` compared `min-elements`/`max-elements` with `int()`, which crashed (`ValueError`) when the value was `unbounded`.
  This change:
  - Treats `unbounded` as infinity instead of crashing.
  - Treats absent `min-elements`/`max-elements` as their RFC 7950 defaults (0 and unbounded), so an absent statement equals its default in both directions (e.g. none <-> `min-elements 0` and none <->
  `max-elements unbounded` are not flagged).
  - Adds test module `l` to `test_update` covering all branches.